### PR TITLE
ocaml-jit hooks - possible alternate API

### DIFF
--- a/.depend
+++ b/.depend
@@ -6522,9 +6522,9 @@ toplevel/native/topeval.cmo : \
     typing/typedtree.cmi \
     typing/typecore.cmi \
     lambda/translmod.cmi \
+    toplevel/native/tophooks.cmi \
     toplevel/topcommon.cmi \
     lambda/simplif.cmi \
-    asmcomp/proc.cmi \
     typing/printtyped.cmi \
     typing/printtyp.cmi \
     lambda/printlambda.cmi \
@@ -6536,21 +6536,15 @@ toplevel/native/topeval.cmo : \
     utils/load_path.cmi \
     lambda/lambda.cmi \
     typing/includemod.cmi \
-    middle_end/flambda/import_approx.cmi \
     typing/ident.cmi \
-    middle_end/flambda/flambda_middle_end.cmi \
     typing/env.cmi \
     utils/config.cmi \
     driver/compmisc.cmi \
     middle_end/compilenv.cmi \
-    middle_end/closure/closure_middle_end.cmi \
     utils/clflags.cmi \
-    middle_end/backend_intf.cmi \
     parsing/asttypes.cmi \
     parsing/ast_helper.cmi \
     asmcomp/asmlink.cmi \
-    asmcomp/asmgen.cmi \
-    asmcomp/arch.cmo \
     toplevel/native/topeval.cmi
 toplevel/native/topeval.cmx : \
     utils/warnings.cmx \
@@ -6559,9 +6553,9 @@ toplevel/native/topeval.cmx : \
     typing/typedtree.cmx \
     typing/typecore.cmx \
     lambda/translmod.cmx \
+    toplevel/native/tophooks.cmx \
     toplevel/topcommon.cmx \
     lambda/simplif.cmx \
-    asmcomp/proc.cmx \
     typing/printtyped.cmx \
     typing/printtyp.cmx \
     lambda/printlambda.cmx \
@@ -6573,25 +6567,52 @@ toplevel/native/topeval.cmx : \
     utils/load_path.cmx \
     lambda/lambda.cmx \
     typing/includemod.cmx \
-    middle_end/flambda/import_approx.cmx \
     typing/ident.cmx \
-    middle_end/flambda/flambda_middle_end.cmx \
     typing/env.cmx \
     utils/config.cmx \
     driver/compmisc.cmx \
     middle_end/compilenv.cmx \
-    middle_end/closure/closure_middle_end.cmx \
     utils/clflags.cmx \
-    middle_end/backend_intf.cmi \
     parsing/asttypes.cmi \
     parsing/ast_helper.cmx \
     asmcomp/asmlink.cmx \
-    asmcomp/asmgen.cmx \
-    asmcomp/arch.cmx \
     toplevel/native/topeval.cmi
 toplevel/native/topeval.cmi : \
     toplevel/topcommon.cmi \
     parsing/parsetree.cmi
+toplevel/native/tophooks.cmo : \
+    toplevel/topcommon.cmi \
+    asmcomp/proc.cmi \
+    utils/misc.cmi \
+    middle_end/flambda/import_approx.cmi \
+    middle_end/flambda/flambda_middle_end.cmi \
+    utils/config.cmi \
+    middle_end/compilenv.cmi \
+    middle_end/closure/closure_middle_end.cmi \
+    utils/clflags.cmi \
+    middle_end/backend_intf.cmi \
+    asmcomp/asmlink.cmi \
+    asmcomp/asmgen.cmi \
+    asmcomp/arch.cmo \
+    toplevel/native/tophooks.cmi
+toplevel/native/tophooks.cmx : \
+    toplevel/topcommon.cmx \
+    asmcomp/proc.cmx \
+    utils/misc.cmx \
+    middle_end/flambda/import_approx.cmx \
+    middle_end/flambda/flambda_middle_end.cmx \
+    utils/config.cmx \
+    middle_end/compilenv.cmx \
+    middle_end/closure/closure_middle_end.cmx \
+    utils/clflags.cmx \
+    middle_end/backend_intf.cmi \
+    asmcomp/asmlink.cmx \
+    asmcomp/asmgen.cmx \
+    asmcomp/arch.cmx \
+    toplevel/native/tophooks.cmi
+toplevel/native/tophooks.cmi : \
+    toplevel/topcommon.cmi \
+    lambda/lambda.cmi
 toplevel/native/topmain.cmo : \
     toplevel/toploop.cmi \
     toplevel/native/topeval.cmi \

--- a/.depend
+++ b/.depend
@@ -6584,6 +6584,7 @@ toplevel/native/tophooks.cmo : \
     toplevel/topcommon.cmi \
     asmcomp/proc.cmi \
     utils/misc.cmi \
+    lambda/lambda.cmi \
     middle_end/flambda/import_approx.cmi \
     middle_end/flambda/flambda_middle_end.cmi \
     utils/config.cmi \
@@ -6599,6 +6600,7 @@ toplevel/native/tophooks.cmx : \
     toplevel/topcommon.cmx \
     asmcomp/proc.cmx \
     utils/misc.cmx \
+    lambda/lambda.cmx \
     middle_end/flambda/import_approx.cmx \
     middle_end/flambda/flambda_middle_end.cmx \
     utils/config.cmx \

--- a/Makefile
+++ b/Makefile
@@ -567,6 +567,7 @@ endif
 	$(INSTALL_DATA) \
 	   utils/*.cmx parsing/*.cmx typing/*.cmx bytecomp/*.cmx \
 	   toplevel/*.cmx toplevel/native/*.cmx \
+	   toplevel/native/tophooks.cmi \
 	   file_formats/*.cmx \
 	   lambda/*.cmx \
 	   driver/*.cmx asmcomp/*.cmx middle_end/*.cmx \

--- a/asmcomp/x86_proc.ml
+++ b/asmcomp/x86_proc.ml
@@ -221,6 +221,11 @@ let string_of_rounding = function
 
 let internal_assembler = ref None
 let register_internal_assembler f = internal_assembler := Some f
+let with_internal_assembler f g =
+  let current = !internal_assembler in
+  let finally () = internal_assembler := current in
+  internal_assembler := Some f;
+  Fun.protect ~finally g
 
 (* Which asm conventions to use *)
 let masm =

--- a/asmcomp/x86_proc.mli
+++ b/asmcomp/x86_proc.mli
@@ -87,3 +87,5 @@ val use_plt : bool
 (** Support for plumbing a binary code emitter *)
 
 val register_internal_assembler: (asm_program -> string -> unit) -> unit
+val with_internal_assembler:
+  (asm_program -> string -> unit) -> (unit -> 'a) -> 'a

--- a/compilerlibs/Makefile.compilerlibs
+++ b/compilerlibs/Makefile.compilerlibs
@@ -366,6 +366,7 @@ TOPLEVEL_CMI = \
 OPTTOPLEVEL = \
   toplevel/genprintval.cmo \
   toplevel/topcommon.cmo \
+  toplevel/native/tophooks.cmo \
   toplevel/native/topeval.cmo \
   toplevel/native/trace.cmo \
   toplevel/toploop.cmo \
@@ -373,6 +374,7 @@ OPTTOPLEVEL = \
   toplevel/native/topmain.cmo
 OPTTOPLEVEL_CMI = \
   toplevel/topcommon.cmi \
+  toplevel/native/tophooks.cmi \
   toplevel/native/topeval.cmi \
   toplevel/native/trace.cmi \
   toplevel/toploop.cmi \

--- a/toplevel/native/topeval.ml
+++ b/toplevel/native/topeval.ml
@@ -16,7 +16,6 @@
 (* The interactive toplevel loop *)
 
 open Format
-open Config
 open Misc
 open Parsetree
 open Types
@@ -24,38 +23,14 @@ open Typedtree
 open Outcometree
 open Topcommon
 
-type res = Ok of Obj.t | Err of string
-
-let _dummy = (Ok (Obj.magic 0), Err "")
-
-external ndl_run_toplevel: string -> string -> res
-  = "caml_natdynlink_run_toplevel"
-
 let implementation_label = "native toplevel"
-
-let lookup sym =
-  Dynlink.unsafe_get_global_value ~bytecode_or_asm_symbol:sym
 
 let global_symbol id =
   let sym = Compilenv.symbol_for_global id in
-  match lookup sym with
+  match Tophooks.lookup sym with
   | None ->
     fatal_error ("Toploop.global_symbol " ^ (Ident.unique_name id))
   | Some obj -> obj
-
-let need_symbol sym =
-  Option.is_none (Dynlink.unsafe_get_global_value ~bytecode_or_asm_symbol:sym)
-
-let dll_run dll entry =
-  match (try Result (Obj.magic (ndl_run_toplevel dll entry))
-         with exn -> Exception exn)
-  with
-    | Exception _ as r -> r
-    | Result r ->
-        match Obj.magic r with
-          | Ok x -> Result x
-          | Err s -> fatal_error ("Toploop.dll_run " ^ s)
-
 
 let remembered = ref Ident.empty
 
@@ -111,61 +86,6 @@ include Topcommon.MakeEvalPrinter(EvalBase)
 
 let may_trace = ref false (* Global lock on tracing *)
 
-(* CR-soon trefis for mshinwell: copy/pasted from Optmain. Should it be shared
-   or?
-   mshinwell: It should be shared, but after 4.03. *)
-module Backend = struct
-  (* See backend_intf.mli. *)
-
-  let symbol_for_global' = Compilenv.symbol_for_global'
-  let closure_symbol = Compilenv.closure_symbol
-
-  let really_import_approx = Import_approx.really_import_approx
-  let import_symbol = Import_approx.import_symbol
-
-  let size_int = Arch.size_int
-  let big_endian = Arch.big_endian
-
-  let max_sensible_number_of_arguments =
-    (* The "-1" is to allow for a potential closure environment parameter. *)
-    Proc.max_arguments_for_tailcalls - 1
-end
-let backend = (module Backend : Backend_intf.S)
-
-let load ppf phrase_name program =
-  let dll =
-    if !Clflags.keep_asm_file then phrase_name ^ ext_dll
-    else Filename.temp_file ("caml" ^ phrase_name) ext_dll
-  in
-  let filename = Filename.chop_extension dll in
-  let middle_end =
-    if Config.flambda then Flambda_middle_end.lambda_to_clambda
-    else Closure_middle_end.lambda_to_clambda
-  in
-  Asmgen.compile_implementation ~toplevel:need_symbol
-    ~backend ~prefixname:filename
-    ~middle_end ~ppf_dump:ppf program;
-  Asmlink.call_linker_shared [filename ^ ext_obj] dll;
-  Sys.remove (filename ^ ext_obj);
-
-  let dll =
-    if Filename.is_implicit dll
-    then Filename.concat (Sys.getcwd ()) dll
-    else dll in
-  match
-    Fun.protect
-      ~finally:(fun () ->
-          (try Sys.remove dll with Sys_error _ -> ()))
-            (* note: under windows, cannot remove a loaded dll
-               (should remember the handles, close them in at_exit, and then
-               remove files) *)
-      (fun () -> dll_run dll phrase_name)
-  with
-  | res -> res
-  | exception x ->
-      record_backtrace ();
-      Exception x
-
 let load_lambda ppf ~module_ident ~required_globals phrase_name lam size =
   if !Clflags.dump_rawlambda then fprintf ppf "%a@." Printlambda.lambda lam;
   let slam = Simplif.simplify_lambda lam in
@@ -179,7 +99,7 @@ let load_lambda ppf ~module_ident ~required_globals phrase_name lam size =
       required_globals;
     }
   in
-  load ppf phrase_name program
+  Tophooks.load ppf phrase_name program
 
 (* Print the outcome of an evaluation *)
 

--- a/toplevel/native/topeval.ml
+++ b/toplevel/native/topeval.ml
@@ -25,7 +25,6 @@ open Outcometree
 open Topcommon
 
 type res = Ok of Obj.t | Err of string
-type evaluation_outcome = Result of Obj.t | Exception of exn
 
 let _dummy = (Ok (Obj.magic 0), Err "")
 

--- a/toplevel/native/tophooks.ml
+++ b/toplevel/native/tophooks.ml
@@ -1,0 +1,96 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Native toplevel dynamic loading interface *)
+
+open Config
+open Misc
+open Topcommon
+
+type[@warning "-37"] res = Ok of Obj.t | Err of string
+
+external ndl_run_toplevel: string -> string -> res
+  = "caml_natdynlink_run_toplevel"
+
+let lookup sym =
+  Dynlink.unsafe_get_global_value ~bytecode_or_asm_symbol:sym
+
+let need_symbol sym =
+  Option.is_none (Dynlink.unsafe_get_global_value ~bytecode_or_asm_symbol:sym)
+
+let dll_run dll entry =
+  match (try Result (Obj.magic (ndl_run_toplevel dll entry))
+         with exn -> Exception exn)
+  with
+    | Exception _ as r -> r
+    | Result r ->
+        match Obj.magic r with
+          | Ok x -> Result x
+          | Err s -> fatal_error ("Toploop.dll_run " ^ s)
+
+(* CR-soon trefis for mshinwell: copy/pasted from Optmain. Should it be shared
+   or?
+   mshinwell: It should be shared, but after 4.03. *)
+module Backend = struct
+  (* See backend_intf.mli. *)
+
+  let symbol_for_global' = Compilenv.symbol_for_global'
+  let closure_symbol = Compilenv.closure_symbol
+
+  let really_import_approx = Import_approx.really_import_approx
+  let import_symbol = Import_approx.import_symbol
+
+  let size_int = Arch.size_int
+  let big_endian = Arch.big_endian
+
+  let max_sensible_number_of_arguments =
+    (* The "-1" is to allow for a potential closure environment parameter. *)
+    Proc.max_arguments_for_tailcalls - 1
+end
+let backend = (module Backend : Backend_intf.S)
+
+let load ppf phrase_name program =
+  let dll =
+    if !Clflags.keep_asm_file then phrase_name ^ ext_dll
+    else Filename.temp_file ("caml" ^ phrase_name) ext_dll
+  in
+  let filename = Filename.chop_extension dll in
+  let middle_end =
+    if Config.flambda then Flambda_middle_end.lambda_to_clambda
+    else Closure_middle_end.lambda_to_clambda
+  in
+  Asmgen.compile_implementation ~toplevel:need_symbol
+    ~backend ~prefixname:filename
+    ~middle_end ~ppf_dump:ppf program;
+  Asmlink.call_linker_shared [filename ^ ext_obj] dll;
+  Sys.remove (filename ^ ext_obj);
+
+  let dll =
+    if Filename.is_implicit dll
+    then Filename.concat (Sys.getcwd ()) dll
+    else dll in
+  match
+    Fun.protect
+      ~finally:(fun () ->
+          (try Sys.remove dll with Sys_error _ -> ()))
+            (* note: under windows, cannot remove a loaded dll
+               (should remember the handles, close them in at_exit, and then
+               remove files) *)
+      (fun () -> dll_run dll phrase_name)
+  with
+  | res -> res
+  | exception x ->
+      record_backtrace ();
+      Exception x

--- a/toplevel/native/tophooks.ml
+++ b/toplevel/native/tophooks.ml
@@ -94,3 +94,18 @@ let load ppf phrase_name program =
   | exception x ->
       record_backtrace ();
       Exception x
+
+type lookup_fn = string -> Obj.t option
+type load_fn =
+  Format.formatter -> string -> Lambda.program -> Topcommon.evaluation_outcome
+type assembler = {mutable lookup: lookup_fn; mutable load: load_fn}
+
+let fns = {lookup; load}
+
+let load ppf = fns.load ppf
+
+let lookup sym = fns.lookup sym
+
+let register_loader ~lookup ~load =
+  fns.lookup <- lookup;
+  fns.load <- load

--- a/toplevel/native/tophooks.mli
+++ b/toplevel/native/tophooks.mli
@@ -1,0 +1,23 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** This module contains sections of Topeval in native code which can be
+    overridden, for example to change the linker.
+*)
+
+val lookup : string -> Obj.t option
+
+val load :
+  Format.formatter -> string -> Lambda.program -> Topcommon.evaluation_outcome

--- a/toplevel/native/tophooks.mli
+++ b/toplevel/native/tophooks.mli
@@ -17,7 +17,19 @@
     overridden, for example to change the linker.
 *)
 
-val lookup : string -> Obj.t option
-
-val load :
+type lookup_fn = string -> Obj.t option
+type load_fn =
   Format.formatter -> string -> Lambda.program -> Topcommon.evaluation_outcome
+
+val lookup : lookup_fn
+(** Find a global symbol by name. Default implementation may be overridden
+    with {!register_assembler}. *)
+
+val load : load_fn
+(** [load ppf phrase_name lambda] compiles and evaluates [lambda]. [phrase_name]
+    may be used for temporary files and is unique. [ppf] may be used for
+    debugging output. Default implementation may be overridden with
+    {!register_loader}. *)
+
+val register_loader : lookup:lookup_fn -> load:load_fn -> unit
+(** Sets the functions used for {!lookup} and {!load}. *)


### PR DESCRIPTION
The overall diff of this is slightly bigger, but the API is cleaner - I'm as keen on having a module in the bytecode toplevel API called `Native` as I am having the module for accessing the Windows system living in a library called win32unix 🙂

This is best viewed commit-by-commit, which is how I'd recommend it's reviewed if we upstream it this way:
- "Remove duplicated type definition in Topeval" - fairly sure that's a bug fix, if an innocuous one
- "Factor out load/lookup functions in native Topeval" - splits the functions ready to be moved
- "Make Topeval.phrase_name less exposed" - adds an extra parameter to limit the scope of the `phrase_name` ref (this removes the need to add an accessor function later)
- "Introduce native-toplevel specific hooks module" - this is the big part of the diff, but this commit is _strictly_ moving code only. Here we move the bits we want to override into a new module called `Tophooks` (the name can be anything). This then makes it quite clear that the code only works in native.
- "Allow the native toplevel assembler to be replaced" - this then adapts what was there before to allow the load and lookup functions to be overridden. I've removed references to JIT, as I think it's clearer to refer to it as overriding the assembler/link stage, but the name can also be changed!
- We can't expose `X86_proc.internal_assembler` and have a pre-existing registration function! So I added a `with_internal_assembler` function instead
- I've exposed `Tophooks.need_symbol` although I'm certain we need to - can't ocaml-jit just call the expansion of this function instead?