### PR TITLE
glibc - 3.07-4.09 back-port of 10266 and 10726

### DIFF
--- a/Changes
+++ b/Changes
@@ -17,6 +17,15 @@ OCaml 4.09 maintenance branch
   (report by Emilio Jesús Gallego Arias, analysis and fix by Stephen Dolan,
    code by Xavier Leroy, review by Hugo Heuzard and Gabriel Scherer)
 
+- #10250, #10266: Dynamically allocate alternate signal stacks to
+  accommodate changes in Glibc 2.34.
+  (Xavier Leroy, reports by Tomasz Kłoczko and R.W.M. Jones, review by Anil
+   Madhavapeddy, Stephen Dolan, and Florian Angeletti)
+
+- #10698, #10726, #10891: Free the alternate signal stack when the main OCaml
+  code or an OCaml thread stops.
+  (Xavier Leroy, review by David Allsopp, Florian Angeletti and Damien Doligez)
+
 OCaml 4.09.1 (16 Mars 2020):
 ----------------------------
 

--- a/Changes
+++ b/Changes
@@ -10,6 +10,13 @@ OCaml 4.09 maintenance branch
   prevent their C99-compliant snprintf conflicting with ours.
   (David Allsopp, report by Michael Soegtrop, review by Xavier Leroy)
 
+### Bug fixes:
+
+- #9326, #10125: Gc.set incorrectly handles the three `custom_*` fields,
+  causing a performance regression
+  (report by Emilio Jesús Gallego Arias, analysis and fix by Stephen Dolan,
+   code by Xavier Leroy, review by Hugo Heuzard and Gabriel Scherer)
+
 OCaml 4.09.1 (16 Mars 2020):
 ----------------------------
 
@@ -334,16 +341,6 @@ OCaml 4.09.0 (19 September 2019):
 
 - #8944: Fix "open struct .. end" on clambda backend
   (Thomas Refis, review by Leo White, report by Damon Wang and Mark Shinwell)
-
-OCaml 4.08 maintenance branch
------------------------------
-
-### Bug fixes:
-
-- #9326, #10125: Gc.set incorrectly handles the three `custom_*` fields,
-  causing a performance regression
-  (report by Emilio Jesús Gallego Arias, analysis and fix by Stephen Dolan,
-   code by Xavier Leroy, review by Hugo Heuzard and Gabriel Scherer)
 
 OCaml 4.08.1 (5 August 2019)
 ----------------------------

--- a/runtime/fail_nat.c
+++ b/runtime/fail_nat.c
@@ -31,6 +31,8 @@
 #include "caml/roots.h"
 #include "caml/callback.h"
 
+extern void caml_terminate_signals(void);
+
 /* The globals holding predefined exceptions */
 
 typedef value caml_generated_constant[1];
@@ -60,7 +62,10 @@ char * caml_exception_pointer = NULL;
 void caml_raise(value v)
 {
   Unlock_exn();
-  if (caml_exception_pointer == NULL) caml_fatal_uncaught_exception(v);
+  if (caml_exception_pointer == NULL) {
+    caml_terminate_signals();
+    caml_fatal_uncaught_exception(v);
+  }
 
   while (caml_local_roots != NULL &&
          (char *) caml_local_roots < caml_exception_pointer) {

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -92,6 +92,7 @@ void (*caml_termination_hook)(void *) = NULL;
 extern value caml_start_program (void);
 extern void caml_init_ieee_floats (void);
 extern void caml_init_signals (void);
+extern void caml_terminate_signals(void);
 #ifdef _WIN32
 extern void caml_win32_overflow_detection (void);
 #endif
@@ -106,6 +107,7 @@ extern void caml_install_invalid_parameter_handler();
 value caml_startup_common(char_os **argv, int pooling)
 {
   char_os * exe_name, * proc_self_exe;
+  value res;
   char tos;
 
   /* Determine options */
@@ -153,10 +155,13 @@ value caml_startup_common(char_os **argv, int pooling)
     exe_name = caml_search_exe_in_path(exe_name);
   caml_sys_init(exe_name, argv);
   if (sigsetjmp(caml_termination_jmpbuf.buf, 0)) {
+    caml_terminate_signals();
     if (caml_termination_hook != NULL) caml_termination_hook(NULL);
     return Val_unit;
   }
-  return caml_start_program();
+  res = caml_start_program();
+  caml_terminate_signals();
+  return res;
 }
 
 value caml_startup_exn(char_os **argv)

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -112,6 +112,8 @@ static void caml_sys_check_path(value name)
   }
 }
 
+extern void caml_terminate_signals(void);
+
 CAMLprim value caml_sys_exit(value retcode_v)
 {
   int retcode = Int_val(retcode_v);
@@ -155,6 +157,9 @@ CAMLprim value caml_sys_exit(value retcode_v)
     caml_shutdown();
 #ifdef _WIN32
   caml_restore_win32_terminal();
+#endif
+#ifdef NATIVE_CODE
+  caml_terminate_signals();
 #endif
   exit(retcode);
 }


### PR DESCRIPTION
`caml_setup_stack_overflow_detection` wasn't added until 4.10 in order to fix stack overflow detection in systhreads. That's not being back-ported, as it's not necessary to maintain the compilation of these older compilers.

The `malloc` is therefore in `caml_init_signals`. The `caml_terminate_signals` part of the patch is fully back-ported.

As in the 4.10-4.12 version, no headers are touched by the change (each C files declares the required function directly).

The 3.07-4.05 versions include the reset of `SIGILL` for anyone who has access to very old Power hardware and 3.07-4.02 don't reset `SIGFPE`, since s390x support was added in 4.03.