### PR TITLE
Install META files to the compiler's Standard Library

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -50,6 +50,7 @@ VERSION                  typo.missing-header
 api_docgen/*.mld                typo.missing-header
 api_docgen/alldoc.tex           typo.missing-header
 tools/mantis2gh_stripped.csv typo.missing-header
+META                     typo.missing-header
 
 *.adoc                   typo.long-line=may typo.very-long-line=may
 

--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,7 @@ _build
 
 /otherlibs/*/.dep
 /otherlibs/dynlink/extract_crc
+/otherlibs/dynlink/META
 /otherlibs/dynlink/dynlink_platform_intf.mli
 /otherlibs/dynlink/byte/dynlink.mli
 /otherlibs/dynlink/native/dynlink.mli

--- a/Changes
+++ b/Changes
@@ -290,6 +290,12 @@ OCaml 5.0
   from +compiler-libs, as the debugger does.
   (David Allsopp, review by Sébastien Hinderer)
 
+- #11007: META files for the stdlib, compiler-libs and other libraries (unix,
+  dynlink, str, runtime_events, threads, ocamldoc) are now installed along with
+  the compiler.
+  (David Allsopp, Florian Angeletti, Nicolás Ojeda Bär and Sébastien Hinderer,
+   review by Daniel Bünzli, Kate Deplaix, Anil Madhavapeddy and Gabriel Scherer)
+
 ### Build system:
 
 * #10893: Remove configuration options --disable-force-safe-string and

--- a/Makefile
+++ b/Makefile
@@ -1468,7 +1468,7 @@ ifeq "$(INSTALL_SOURCE_ARTIFACTS)" "true"
 	   "$(INSTALL_COMPLIBDIR)"
 endif
 	$(INSTALL_DATA) \
-	  compilerlibs/*.cma \
+	  compilerlibs/*.cma compilerlibs/META \
 	  "$(INSTALL_COMPLIBDIR)"
 	$(INSTALL_DATA) \
 	   $(BYTESTART) $(TOPLEVELSTART) \

--- a/compilerlibs/META
+++ b/compilerlibs/META
@@ -1,0 +1,43 @@
+version = "[distributed with OCaml]"
+description = "compiler-libs support library"
+directory= "+compiler-libs"
+
+package "common" (
+  requires = "compiler-libs"
+  version = "[distributed with OCaml]"
+  description = "Common compiler routines"
+  archive(byte) = "ocamlcommon.cma"
+  archive(native) = "ocamlcommon.cmxa"
+)
+
+package "bytecomp" (
+  requires = "compiler-libs.common"
+  version = "[distributed with OCaml]"
+  description = "Bytecode compiler"
+  archive(byte) = "ocamlbytecomp.cma"
+  archive(native) = "ocamlbytecomp.cmxa"
+)
+
+package "optcomp" (
+  requires = "compiler-libs.common"
+  version = "[distributed with OCaml]"
+  description = "Native-code compiler"
+  archive(byte) = "ocamloptcomp.cma"
+  archive(native) = "ocamloptcomp.cmxa"
+  exists_if = "ocamloptcomp.cma"
+)
+
+package "toplevel" (
+  requires = "compiler-libs.bytecomp"
+  version = "[distributed with OCaml]"
+  description = "Toplevel interactions"
+  archive(byte) = "ocamltoplevel.cma"
+)
+
+package "native-toplevel" (
+  requires = "compiler-libs.optcomp dynlink"
+  version = "[distributed with OCaml]"
+  description = "Toplevel interactions"
+  archive(native) = "ocamltoplevel.cmxa"
+  exists_if = "ocamltoplevel.cmxa"
+)

--- a/configure
+++ b/configure
@@ -794,6 +794,7 @@ instrumented_runtime_libs
 instrumented_runtime
 debug_runtime
 cmxs
+natdynlink_archive
 natdynlinkopts
 natdynlink
 supports_shared_libraries
@@ -2928,6 +2929,7 @@ OCAML_VERSION_SHORT=5.1
 
 
 
+
  # TODO: rename this variable
 
 
@@ -2972,6 +2974,8 @@ ac_config_files="$ac_config_files Makefile.build_config"
 ac_config_files="$ac_config_files Makefile.config"
 
 ac_config_files="$ac_config_files stdlib/sys.ml"
+
+ac_config_files="$ac_config_files otherlibs/dynlink/META"
 
 ac_config_files="$ac_config_files manual/src/version.tex"
 
@@ -14460,6 +14464,11 @@ if $natdynlink; then :
 else
   cmxs="cmx"
 fi
+if $natdynlink; then :
+  natdynlink_archive="dynlink.cmxa"
+else
+  natdynlink_archive=""
+fi
 
 cat >>confdefs.h <<_ACEOF
 #define OCAML_OS_TYPE "$ostype"
@@ -19274,6 +19283,7 @@ do
     "Makefile.build_config") CONFIG_FILES="$CONFIG_FILES Makefile.build_config" ;;
     "Makefile.config") CONFIG_FILES="$CONFIG_FILES Makefile.config" ;;
     "stdlib/sys.ml") CONFIG_FILES="$CONFIG_FILES stdlib/sys.ml" ;;
+    "otherlibs/dynlink/META") CONFIG_FILES="$CONFIG_FILES otherlibs/dynlink/META" ;;
     "manual/src/version.tex") CONFIG_FILES="$CONFIG_FILES manual/src/version.tex" ;;
     "manual/src/html_processing/src/common.ml") CONFIG_FILES="$CONFIG_FILES manual/src/html_processing/src/common.ml" ;;
     "runtime/caml/m.h") CONFIG_HEADERS="$CONFIG_HEADERS runtime/caml/m.h" ;;

--- a/configure.ac
+++ b/configure.ac
@@ -129,6 +129,7 @@ AC_SUBST([mklib])
 AC_SUBST([supports_shared_libraries])
 AC_SUBST([natdynlink])
 AC_SUBST([natdynlinkopts])
+AC_SUBST([natdynlink_archive])
 AC_SUBST([cmxs])
 AC_SUBST([debug_runtime])
 AC_SUBST([instrumented_runtime])
@@ -179,6 +180,7 @@ AC_SUBST([QS])
 AC_CONFIG_FILES([Makefile.build_config])
 AC_CONFIG_FILES([Makefile.config])
 AC_CONFIG_FILES([stdlib/sys.ml])
+AC_CONFIG_FILES([otherlibs/dynlink/META])
 AC_CONFIG_FILES([manual/src/version.tex])
 AC_CONFIG_FILES([manual/src/html_processing/src/common.ml])
 AC_CONFIG_HEADERS([runtime/caml/m.h])
@@ -1200,6 +1202,9 @@ AS_CASE([$enable_native_compiler,$arch],
 AS_IF([! $native_compiler], [natdynlink=false])
 
 AS_IF([$natdynlink], [cmxs="cmxs"], [cmxs="cmx"])
+AS_IF([$natdynlink],
+  [natdynlink_archive="dynlink.cmxa"],
+  [natdynlink_archive=""])
 
 AC_DEFINE_UNQUOTED([OCAML_OS_TYPE], ["$ostype"])
 

--- a/ocamldoc/META
+++ b/ocamldoc/META
@@ -1,0 +1,4 @@
+requires = "compiler-libs"
+version = "[distributed with OCaml]"
+description = "ocamldoc plugin interface"
+directory= "+ocamldoc"

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -219,7 +219,7 @@ install:
 	$(MKDIR) "$(INSTALL_LIBDIR)/ocamldoc"
 	$(INSTALL_PROG) $(OCAMLDOC) "$(INSTALL_BINDIR)"
 	$(INSTALL_DATA) \
-	  ocamldoc.hva *.cmi $(OCAMLDOC_LIBCMA) \
+	  ocamldoc.hva *.cmi $(OCAMLDOC_LIBCMA) META \
 	  "$(INSTALL_LIBDIR)/ocamldoc"
 	$(INSTALL_DATA) \
 	  $(OCAMLDOC_LIBCMIS) \

--- a/otherlibs/Makefile.otherlibs.common
+++ b/otherlibs/Makefile.otherlibs.common
@@ -103,7 +103,7 @@ endif
           $(CAMLOBJS_NAT) $(LIBNAME).cmxa $(LIBNAME).cmxs $(LIBNAME).$(A))
 	$(MKDIR) "$(INSTALL_LIBDIR_LIBNAME)"
 	$(INSTALL_DATA) \
-	  $(LIBNAME).cma $(CMIFILES) \
+	  $(LIBNAME).cma $(CMIFILES) META \
 	  "$(INSTALL_LIBDIR_LIBNAME)/"
 ifeq "$(INSTALL_SOURCE_ARTIFACTS)" "true"
 	$(INSTALL_DATA) \

--- a/otherlibs/dynlink/META.in
+++ b/otherlibs/dynlink/META.in
@@ -1,0 +1,6 @@
+# @configure_input@
+version = "[distributed with OCaml]"
+description = "Dynamic loading and linking of object files"
+directory = "+dynlink"
+archive(byte) = "dynlink.cma"
+archive(native) = "@natdynlink_archive@"

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -252,7 +252,7 @@ install:
         $(addprefix "$(INSTALL_LIBDIR)/", $(notdir $(NATOBJS)))
 	$(MKDIR) "$(INSTALL_LIBDIR_DYNLINK)"
 	$(INSTALL_DATA) \
-	  dynlink.cmi dynlink.cma \
+	  dynlink.cmi dynlink.cma META \
 	  "$(INSTALL_LIBDIR_DYNLINK)"
 ifeq "$(INSTALL_SOURCE_ARTIFACTS)" "true"
 	$(INSTALL_DATA) \
@@ -282,6 +282,7 @@ clean: partialclean
 
 .PHONY: distclean
 distclean: clean
+	rm -f META
 
 .PHONY: beforedepend
 beforedepend: dynlink_platform_intf.mli

--- a/otherlibs/runtime_events/META
+++ b/otherlibs/runtime_events/META
@@ -1,0 +1,7 @@
+description = "Ring buffer-based runtime tracing"
+version = "[distributed with OCaml]"
+directory = "+runtime_events"
+archive(byte) = "runtime_events.cma"
+archive(native) = "runtime_events.cmxa"
+plugin(byte) = "runtime_events.cma"
+plugin(native) = "runtime_events.cmxs"

--- a/otherlibs/str/META
+++ b/otherlibs/str/META
@@ -1,0 +1,7 @@
+description = "Regular expressions and string processing"
+version = "[distributed with OCaml]"
+directory = "+str"
+archive(byte) = "str.cma"
+archive(native) = "str.cmxa"
+plugin(byte) = "str.cma"
+plugin(native) = "str.cmxs"

--- a/otherlibs/systhreads/META
+++ b/otherlibs/systhreads/META
@@ -1,0 +1,19 @@
+version = "[distributed with OCaml]"
+description = "Multi-threading"
+requires(mt,mt_posix) = "threads.posix"
+directory = "+"
+type_of_threads = "posix"
+
+package "posix" (
+  requires = "unix"
+  directory = "+threads"
+  exists_if = "threads.cma"
+  archive(byte,mt,mt_posix) = "threads.cma"
+  archive(native,mt,mt_posix) = "threads.cmxa"
+  version = "[internal]"
+)
+
+package "none" (
+  error = "threading is not supported on this platform"
+  version = "[internal]"
+)

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -121,7 +121,7 @@ install:
 	$(INSTALL_DATA) libthreads.$(A) "$(INSTALL_LIBDIR)"
 	$(MKDIR) "$(INSTALL_THREADSLIBDIR)"
 	$(INSTALL_DATA) \
-	  $(CMIFILES) threads.cma \
+	  $(CMIFILES) threads.cma META \
 	  "$(INSTALL_THREADSLIBDIR)"
 ifeq "$(INSTALL_SOURCE_ARTIFACTS)" "true"
 	$(INSTALL_DATA) \

--- a/otherlibs/unix/META
+++ b/otherlibs/unix/META
@@ -1,0 +1,7 @@
+description = "Unix system calls"
+version = "[distributed with OCaml]"
+directory = "+unix"
+archive(byte) = "unix.cma"
+archive(native) = "unix.cmxa"
+plugin(byte) = "unix.cma"
+plugin(native) = "unix.cmxs"

--- a/stdlib/META
+++ b/stdlib/META
@@ -1,0 +1,3 @@
+description = "Standard library"
+version = "[distributed with OCaml]"
+directory = "+"

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -66,10 +66,14 @@ install::
     exit 1; \
   fi
 
+INSTALL_STDLIB_META_DIR=$(DESTDIR)$(LIBDIR)/stdlib
+
 install::
 	$(INSTALL_DATA) \
 	  stdlib.cma std_exit.cmo *.cmi camlheader_ur \
 	  "$(INSTALL_LIBDIR)"
+	$(MKDIR) "$(INSTALL_STDLIB_META_DIR)"
+	$(INSTALL_DATA) META "$(INSTALL_STDLIB_META_DIR)"
 ifeq "$(INSTALL_SOURCE_ARTIFACTS)" "true"
 	$(INSTALL_DATA) \
 	  *.cmt *.cmti *.mli *.ml \


### PR DESCRIPTION
See also 

This simplified version of the original treats the compiler's Standard Library directory as a findlib site-lib and installs `META` files to sub-directories. The linked PRs then use their pre-existing mechanisms for `OCAMLPATH` to include these.

---

The addition of `SITELIBDIR` adds unnecessary complexity to this - TL;DR we should go with `@nojb`'s original suggestion of altering the search paths of Dune and findlib and this is demonstrated in https://github.com/dra27/ocaml/pull/62 alongside https://github.com/dra27/dune/pull/4 and https://github.com/dra27/ocamlfind/pull/1. There is _no change_ required for opam-repository to facilitate this. Crucially, this _always_ works for Dune and findlib both independently of each other and independently of opam.

The problem with adding `SITELIBDIR` to the compiler, is that _both_ findlib and Dune need to be configured with the same directory to pick up these new `META` files. Note also that no matter what we do, findlib and Dune **do** require updates, contrary to `https://github.com/ocaml/ocaml/pull/11007#pullrequestreview-880996986`. ocamlfind's detection of existing packages _at first installation_ only applies to the packages which have been moved out of the distribution and Dune's internal ones are _unconditionally loaded_. Without altering them, these new `META` files will never be used.

As it stands, this also completely breaks the `ocaml-system` package in opam-repository. Although it is not possible at present to use an OS package manager's `ocamlfind` with opam, it _is_ possible to use an OS package manager's binary distribution of OCaml with opam and then install `ocamlfind` _in opam_. This gives the twofold flaws for having the compiler support `SITELIBDIR` - it's fundamentally impossible to enforce having the same "sitelib" for both and, worse, it's meaningful to have more than one "sitelib" (the whole point of using system compilers in opam is that you share the compiler between different sets of findlib packages in opam switches). As this PR stands, either:
- The  `ocaml-system` package would have to do a lot of work to locate the compiler's `META` files and then copy them into the switch. This not only adds complexity to `ocaml-system`, but it's also brittle - we can't guarantee being able to find them, unless we start putting `SITELIBDIR` in `Makefile.config`, etc.
- Both ocamlfind and dune would need to be able to _fall-back_ to their built-in `META` files if the compiler's aren't found. One of the nice features of the patches liked above for them is that they _never_ use their built-in `META` files for OCaml 5.0+ - i.e. once we get to a point in the future where these tools are OCaml 5.0+ only, they would actually delete code.