### PR TITLE
[Relocatable] 6: Interpret relative paths in `ld.conf` from the location of `ld.conf`

### DIFF
--- a/Changes
+++ b/Changes
@@ -161,6 +161,12 @@ ___________
   runtime assertions.
   (Antonin Décimo, review by Miod Vallat, Gabriel Scherer, and David Allsopp)
 
+* #13???: Explicit relative paths in ld.conf (".", "..", "./<path...>",
+  "../<path...>") are interpreted as being relative to the directory ld.conf
+  was loaded from. The brave may continue to put implicit paths in ld.conf. The
+  interpretation of CAML_LD_LIBRARY_PATH is unaltered.
+  (David Allsopp, review by ???)
+
 ### Code generation and optimizations:
 
 - #13014: Enable compile-time option -function-sections on all previously

--- a/Makefile
+++ b/Makefile
@@ -1357,8 +1357,16 @@ endif
 ## Generated non-object files
 
 runtime/ld.conf: $(ROOTDIR)/Makefile.config
-	$(V_GEN)echo "$(STUBLIBDIR)" > $@ && \
-	echo "$(LIBDIR)" >> $@
+ifneq "$(STUBLIBDIR)" "$(LIBDIR)/stublibs"
+	$(V_GEN)echo "$(STUBLIBDIR)" > $@
+else
+ifeq "$(UNIX_OR_WIN32)" "unix"
+	$(V_GEN)echo './stublibs' > $@
+else
+	$(V_GEN)echo '.\stublibs' > $@
+endif
+endif
+	@echo "." >> $@
 
 runtime/primitives: runtime/gen_primitives.sh $(runtime_BYTECODE_C_SOURCES)
 	$(V_GEN)runtime/gen_primitives.sh $@ $(runtime_BYTECODE_C_SOURCES)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,9 @@ image: Visual Studio 2022
 # Do a shallow clone of the repo to speed up the build
 clone_depth: 1
 
+# Do not build feature branch with open Pull Requests
+skip_branch_with_pr: true
+
 environment:
   global:
     CYG_ROOT: C:/cygwin64

--- a/bytecomp/dll.ml
+++ b/bytecomp/dll.ml
@@ -146,7 +146,16 @@ let ld_conf_contents () =
     let ic = open_in (Filename.concat Config.standard_library "ld.conf") in
     begin try
       while true do
-        path := input_line ic :: !path
+        let entry = input_line ic in
+        let entry =
+          if entry = Filename.current_dir_name
+          || entry = Filename.parent_dir_name
+          || Filename.is_relative entry && not (Filename.is_implicit entry) then
+            Filename.concat Config.standard_library entry
+          else
+            entry
+        in
+        path := entry :: !path
       done
     with End_of_file -> ()
     end;

--- a/runtime/caml/dynlink.h
+++ b/runtime/caml/dynlink.h
@@ -45,7 +45,7 @@ extern void caml_free_shared_libs(void);
 extern char_os * caml_get_stdlib_location(void);
 
 /* Parse ld.conf and add the lines read to caml_shared_libs_path */
-extern char_os * caml_parse_ld_conf(void);
+extern void caml_parse_ld_conf(void);
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -49,8 +49,8 @@ extern int caml_read_fd(int fd, int flags, void * buf, int n);
 extern int caml_write_fd(int fd, int flags, void * buf, int n);
 
 /* Decompose the given path into a list of directories, and add them
-   to the given table. */
-extern char_os * caml_decompose_path(struct ext_table * tbl, char_os * path);
+   to the given table. entries added to tbl are strdup'd. */
+extern void caml_decompose_path(struct ext_table * tbl, char_os * path);
 
 /* Search the given file in the given list of directories.
    If not found, return a copy of [name]. */

--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -142,6 +142,14 @@ CAMLextern clock_t caml_win32_clock(void);
 
 CAMLextern value caml_win32_xdg_defaults(void);
 
+#define CAML_DIR_SEP T("\\")
+#define Is_dir_separator(c) (c == '\\' || c == '/')
+
+#else
+
+#define CAML_DIR_SEP "/"
+#define Is_dir_separator(c) (c == '/')
+
 #endif /* _WIN32 */
 
 /* Returns the current value of a counter that increments once per nanosecond.

--- a/runtime/dynlink.c
+++ b/runtime/dynlink.c
@@ -92,10 +92,10 @@ CAMLexport char_os * caml_get_stdlib_location(void)
   return stdlib;
 }
 
-CAMLexport char_os * caml_parse_ld_conf(void)
+CAMLexport void caml_parse_ld_conf(void)
 {
-  char_os * stdlib, * ldconfname, * wconfig, * p, * q;
-  char * config;
+  char_os * stdlib, * ldconfname;
+  char * config, * p, * q;
 #ifdef _WIN32
   struct _stati64 st;
 #else
@@ -107,7 +107,7 @@ CAMLexport char_os * caml_parse_ld_conf(void)
   ldconfname = caml_stat_strconcat_os(3, stdlib, T("/"), LD_CONF_NAME);
   if (stat_os(ldconfname, &st) == -1) {
     caml_stat_free(ldconfname);
-    return NULL;
+    return;
   }
   ldconf = open_os(ldconfname, O_RDONLY, 0);
   if (ldconf == -1)
@@ -120,20 +120,20 @@ CAMLexport char_os * caml_parse_ld_conf(void)
       ("error while reading loader config file %s",
        caml_stat_strdup_of_os(ldconfname));
   config[nread] = 0;
-  wconfig = caml_stat_strdup_to_os(config);
-  caml_stat_free(config);
-  q = wconfig;
-  for (p = wconfig; *p != 0; p++) {
+  q = config;
+  for (p = config; *p != 0; p++) {
     if (*p == '\n') {
       *p = 0;
-      caml_ext_table_add(&caml_shared_libs_path, q);
+      caml_ext_table_add(&caml_shared_libs_path, caml_stat_strdup_to_os(q));
       q = p + 1;
     }
   }
-  if (q < p) caml_ext_table_add(&caml_shared_libs_path, q);
+  if (q < p)
+    caml_ext_table_add(&caml_shared_libs_path, caml_stat_strdup_to_os(q));
   close(ldconf);
+  caml_stat_free(config);
   caml_stat_free(ldconfname);
-  return wconfig;
+  return;
 }
 
 /* Open the given shared library and add it to shared_libs.
@@ -182,7 +182,7 @@ void caml_build_primitive_table(char_os * lib_path,
                       caml_secure_getenv(T("CAML_LD_LIBRARY_PATH")));
   if (lib_path != NULL)
     for (char_os *p = lib_path; *p != 0; p += strlen_os(p) + 1)
-      caml_ext_table_add(&caml_shared_libs_path, p);
+      caml_ext_table_add(&caml_shared_libs_path, caml_stat_strdup_os(p));
   caml_parse_ld_conf();
   /* Open the shared libraries */
   caml_ext_table_init(&shared_libs, 8);

--- a/runtime/dynlink.c
+++ b/runtime/dynlink.c
@@ -92,10 +92,41 @@ CAMLexport char_os * caml_get_stdlib_location(void)
   return stdlib;
 }
 
+Caml_inline char_os * filename_concat(char_os * path1, char_os * path2)
+{
+  if (Is_dir_separator(path1[strlen_os(path1) - 1]))
+    return caml_stat_strconcat_os(2, path1, path2);
+  else
+    return caml_stat_strconcat_os(3, path1, CAML_DIR_SEP, path2);
+}
+
+static void add_ld_conf_entry(char_os * root, char_os * dir)
+{
+  char_os * entry;
+  size_t len = strlen_os(dir);
+  /* Implicit paths, "." and ".." are treated relative to ld.conf */
+  if ((len == 1 && dir[0] == '.')
+      || (len == 2 && dir[0] == '.' && Is_dir_separator(dir[1]))) {
+    /* "." or "./" - add the directory containing ld.conf */
+    entry = caml_stat_strdup_os(root);
+  } else if (len >= 2 && dir[0] == '.' && dir[1] == '.'
+             && (len == 2 || Is_dir_separator(dir[2]))) {
+    /* ".." or "../<path...>" */
+    entry = filename_concat(root, dir);
+  } else if (len >= 2 && dir[0] == '.' && Is_dir_separator(dir[1])) {
+    /* "./<path...>" */
+    entry = filename_concat(root, dir + 2);
+  } else {
+    /* Absolute or implicit path */
+    entry = caml_stat_strdup_os(dir);
+  }
+  caml_ext_table_add(&caml_shared_libs_path, entry);
+}
+
 CAMLexport void caml_parse_ld_conf(void)
 {
-  char_os * stdlib, * ldconfname;
-  char * config, * p, * q;
+  char_os * stdlib, * ldconfname, * wconfig, * p, * q;
+  char * config;
 #ifdef _WIN32
   struct _stati64 st;
 #else
@@ -120,18 +151,20 @@ CAMLexport void caml_parse_ld_conf(void)
       ("error while reading loader config file %s",
        caml_stat_strdup_of_os(ldconfname));
   config[nread] = 0;
-  q = config;
-  for (p = config; *p != 0; p++) {
+  wconfig = caml_stat_strdup_to_os(config);
+  caml_stat_free(config);
+  q = wconfig;
+  for (p = wconfig; *p != 0; p++) {
     if (*p == '\n') {
       *p = 0;
-      caml_ext_table_add(&caml_shared_libs_path, caml_stat_strdup_to_os(q));
+      add_ld_conf_entry(stdlib, q);
       q = p + 1;
     }
   }
   if (q < p)
-    caml_ext_table_add(&caml_shared_libs_path, caml_stat_strdup_to_os(q));
+    add_ld_conf_entry(stdlib, q);
   close(ldconf);
-  caml_stat_free(config);
+  caml_stat_free(wconfig);
   caml_stat_free(ldconfname);
   return;
 }

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -330,7 +330,8 @@ static int parse_command_line(char_os **argv)
         break;
       case 'I':
         if (argv[i + 1] != NULL) {
-          caml_ext_table_add(&caml_shared_libs_path, argv[i + 1]);
+          caml_ext_table_add(&caml_shared_libs_path,
+                             caml_stat_strdup_os(argv[i + 1]));
           i++;
         } else {
           error("option '-I' needs an argument.");

--- a/runtime/unix.c
+++ b/runtime/unix.c
@@ -114,9 +114,12 @@ int caml_write_fd(int fd, int flags, void * buf, int n)
   return retcode;
 }
 
-caml_stat_string caml_decompose_path(struct ext_table * tbl, char * path)
+static caml_stat_string decompose_path(struct ext_table * tbl,
+                                       char * path,
+                                       int dup)
 {
   char * p, * q;
+  char c;
   size_t n;
 
   if (path == NULL) return NULL;
@@ -124,13 +127,26 @@ caml_stat_string caml_decompose_path(struct ext_table * tbl, char * path)
   q = p;
   while (1) {
     for (n = 0; q[n] != 0 && q[n] != ':'; n++) /*nothing*/;
-    caml_ext_table_add(tbl, q);
-    q = q + n;
-    if (*q == 0) break;
-    *q = 0;
-    q += 1;
+    c = q[n];
+    q[n] = 0;
+    if (dup)
+      caml_ext_table_add(tbl, caml_stat_strdup(q));
+    else
+      caml_ext_table_add(tbl, q);
+    if (c == 0) break;
+    q = q + n + 1;
+  }
+  if (dup) {
+    free(p);
+    p = NULL;
   }
   return p;
+}
+
+void caml_decompose_path(struct ext_table * tbl, char * path)
+{
+  decompose_path(tbl, path, 1);
+  return;
 }
 
 caml_stat_string caml_search_in_path(struct ext_table * path, const char * name)
@@ -204,7 +220,7 @@ caml_stat_string caml_search_exe_in_path(const char * name)
   caml_stat_string res;
 
   caml_ext_table_init(&path, 8);
-  tofree = caml_decompose_path(&path, getenv("PATH"));
+  tofree = decompose_path(&path, getenv("PATH"), 0);
 #ifndef __CYGWIN__
   res = caml_search_in_path(&path, name);
 #else

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -131,23 +131,25 @@ int caml_write_fd(int fd, int flags, void * buf, int n)
   return retcode;
 }
 
-wchar_t * caml_decompose_path(struct ext_table * tbl, wchar_t * path)
+void caml_decompose_path(struct ext_table * tbl, wchar_t * path)
 {
   wchar_t * p, * q;
+  wchar_t c;
   int n;
 
-  if (path == NULL) return NULL;
+  if (path == NULL) return;
   p = caml_stat_wcsdup(path);
   q = p;
   while (1) {
     for (n = 0; q[n] != 0 && q[n] != L';'; n++) /*nothing*/;
-    caml_ext_table_add(tbl, q);
-    q = q + n;
-    if (*q == 0) break;
-    *q = 0;
-    q += 1;
+    c = q[n];
+    q[n] = 0;
+    caml_ext_table_add(tbl, caml_stat_wcsdup(q));
+    if (c == 0) break;
+    q = q + n + 1;
   }
-  return p;
+  caml_stat_free(p);
+  return;
 }
 
 wchar_t * caml_search_in_path(struct ext_table * path, const wchar_t * name)


### PR DESCRIPTION
This PR shares an implementation of "`strdup` entries in `caml_shared_libs_path`" with #73