### PR TITLE
[Relocatable] 9: Silence ld warnings in shared builds of backends

### DIFF
--- a/Changes
+++ b/Changes
@@ -161,6 +161,11 @@ ___________
   runtime assertions.
   (Antonin Décimo, review by Miod Vallat, Gabriel Scherer, and David Allsopp)
 
+- #13???: Add missing .type and .size directives to main frametable to silence
+  warnings from the linker when using libasmrun_shared on i386, amd64 and power.
+  The other backends already carried these directives.
+  (David Allsopp, review by ???)
+
 ### Code generation and optimizations:
 
 - #13014: Enable compile-time option -function-sections on all previously

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -77,8 +77,12 @@
 #if defined(SYS_linux) || defined(SYS_gnu)
 #define ENDFUNCTION(name) \
         .size name, . - name
+#define ENDOBJECT(name) \
+        .type name, @object; \
+        .size name, . - name;
 #else
 #define ENDFUNCTION(name)
+#define ENDOBJECT(name)
 #endif
 
 #include "../runtime/caml/asm.h"
@@ -1331,6 +1335,7 @@ G(caml_system.frametable):
         .quad   LBL(frame_runstack) /* return address into fiber_val_handler */
         .value  -1          /* negative frame size => use callback link */
         .value  0           /* no roots here */
+        ENDOBJECT(G(caml_system.frametable))
 
 #if defined(SYS_macosx)
         .literal16

--- a/runtime/power.S
+++ b/runtime/power.S
@@ -1193,6 +1193,7 @@ caml_system.frametable:
         .short  -1              /* negative frame size => use callback link */
         .short  0               /* no roots here */
         .align 3
+        .size   caml_system.frametable, .-caml_system.frametable
 
 /* TOC entries */
 


### PR DESCRIPTION
This PR sits on #127