### PR TITLE
configure: reuse detection of ln -s support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -57,6 +57,7 @@ META.in                  typo.missing-header
 
 # Github templates and scripts lack headers, have long lines
 /.github/**              typo.missing-header typo.long-line=may typo.very-long-line=may
+/.github/workflows/build-msvc.yml typo.utf8
 
 /.mailmap                typo.long-line typo.missing-header typo.non-ascii
 /CONTRIBUTING.md         typo.non-ascii=may

--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -95,10 +95,12 @@ jobs:
           CC: ${{ matrix.cc }}
         run: >-
           eval $(tools/msvs-promote-path) ;
-          if ! ./configure --cache-file=config.cache --host=$HOST CC=$CC ; then
+          if ! ./configure --cache-file=config.cache --host=$HOST CC=$CC
+          --prefix "$PROGRAMFILES/Бактріан🐫"; then
           rm -rf config.cache ;
           failed=0 ;
-          ./configure --cache-file=config.cache --host=$HOST CC=$CC \
+          ./configure --cache-file=config.cache --host=$HOST CC=$CC
+          --prefix "$PROGRAMFILES/Бактріан🐫"
           || failed=$?;
           if ((failed)) ; then cat config.log ; exit $failed ; fi ;
           fi ;
@@ -136,3 +138,7 @@ jobs:
         run: >-
           eval $(tools/msvs-promote-path) ;
           make -j tests ;
+
+      - name: Install the compiler
+        shell: bash
+        run: make install

--- a/Changes
+++ b/Changes
@@ -69,6 +69,10 @@ Working version
 
 ### Build system:
 
+- #13494: Use native symlinks on Windows for the OCaml installation, reducing
+  disk usage considerably.
+  (David Allsopp, review by Gabriel Scherer)
+
 ### Bug fixes:
 
 - #13408: Fix misplaced debug runtime assertion triggerable by a race

--- a/Makefile
+++ b/Makefile
@@ -692,7 +692,7 @@ coldstart: boot/ocamlrun$(EXE) runtime/libcamlrun.$(A)
 	$(MAKE) -C stdlib OCAMLRUN='$$(ROOTDIR)/$<' USE_BOOT_OCAMLC=true all
 	rm -f $(addprefix boot/, libcamlrun.$(A) $(LIBFILES))
 	cp $(addprefix stdlib/, $(LIBFILES)) boot
-	cd boot; $(LN) ../runtime/libcamlrun.$(A) .
+	cd boot && $(LN_S) ../runtime/libcamlrun.$(A) .
 
 # Recompile the core system using the bootstrap compiler
 .PHONY: coreall
@@ -884,7 +884,7 @@ flexlink.opt$(EXE): \
 	  OCAMLOPT='$(FLEXLINK_OCAMLOPT) -nostdlib -I ../stdlib' flexlink.exe
 	cp $(FLEXDLL_SOURCE_DIR)/flexlink.exe $@
 	rm -f $(OPT_BINDIR)/flexlink$(EXE)
-	cd $(OPT_BINDIR); $(LN) $(call ROOT_FROM, $(OPT_BINDIR))/$@ flexlink$(EXE)
+	cd $(OPT_BINDIR) && $(LN_S) $(call ROOT_FROM, $(OPT_BINDIR))/$@ flexlink$(EXE)
 	cp $(addprefix $(BYTE_BINDIR)/, $(FLEXDLL_OBJECTS)) $(OPT_BINDIR)
 
 else
@@ -1071,7 +1071,7 @@ endif
 # to add otherlibs/dynlink/native to the search path as well
 
 otherlibs/dynlink/dynlink.cmx : otherlibs/dynlink/native/dynlink.cmx
-	cd otherlibs/dynlink; $(LN) native/dynlink.cmx .
+	cd otherlibs/dynlink && $(LN_S) native/dynlink.cmx .
 
 DYNLINK_DEPEND_DUMMY_FILES = \
   otherlibs/dynlink/dynlink.ml \
@@ -1116,28 +1116,28 @@ beforedepend:: lambda/runtimedef.ml
 # Choose the right machine-dependent files
 
 asmcomp/arch.mli: asmcomp/$(ARCH)/arch.mli
-	@cd asmcomp; $(LN) $(ARCH)/arch.mli .
+	@cd asmcomp && $(LN_S) $(ARCH)/arch.mli .
 
 asmcomp/arch.ml: asmcomp/$(ARCH)/arch.ml
-	@cd asmcomp; $(LN) $(ARCH)/arch.ml .
+	@cd asmcomp && $(LN_S) $(ARCH)/arch.ml .
 
 asmcomp/proc.ml: asmcomp/$(ARCH)/proc.ml
-	@cd asmcomp; $(LN) $(ARCH)/proc.ml .
+	@cd asmcomp && $(LN_S) $(ARCH)/proc.ml .
 
 asmcomp/selection.ml: asmcomp/$(ARCH)/selection.ml
-	@cd asmcomp; $(LN) $(ARCH)/selection.ml .
+	@cd asmcomp && $(LN_S) $(ARCH)/selection.ml .
 
 asmcomp/CSE.ml: asmcomp/$(ARCH)/CSE.ml
-	@cd asmcomp; $(LN) $(ARCH)/CSE.ml .
+	@cd asmcomp && $(LN_S) $(ARCH)/CSE.ml .
 
 asmcomp/reload.ml: asmcomp/$(ARCH)/reload.ml
-	@cd asmcomp; $(LN) $(ARCH)/reload.ml .
+	@cd asmcomp && $(LN_S) $(ARCH)/reload.ml .
 
 asmcomp/scheduling.ml: asmcomp/$(ARCH)/scheduling.ml
-	@cd asmcomp; $(LN) $(ARCH)/scheduling.ml .
+	@cd asmcomp && $(LN_S) $(ARCH)/scheduling.ml .
 
 asmcomp/stackframe.ml: asmcomp/$(ARCH)/stackframe.ml
-	@cd asmcomp; $(LN) $(ARCH)/stackframe.ml .
+	@cd asmcomp && $(LN_S) $(ARCH)/stackframe.ml .
 
 # Preprocess the code emitters
 cvt_emit = tools/cvt_emit$(EXE)
@@ -1610,7 +1610,7 @@ runtime: stdlib/libcamlrun.$(A)
 .PHONY: makeruntime
 makeruntime: runtime-all
 stdlib/libcamlrun.$(A): runtime-all
-	cd stdlib; $(LN) ../runtime/libcamlrun.$(A) .
+	cd stdlib && $(LN_S) ../runtime/libcamlrun.$(A) .
 clean::
 	rm -f $(addprefix runtime/, *.o *.obj *.a *.lib *.so *.dll ld.conf)
 	rm -f $(addprefix runtime/, ocamlrun ocamlrund ocamlruni ocamlruns sak)
@@ -1628,9 +1628,9 @@ runtimeopt: stdlib/libasmrun.$(A)
 .PHONY: makeruntimeopt
 makeruntimeopt: runtime-allopt
 stdlib/libasmrun.$(A): runtime-allopt
-	cd stdlib; $(LN) ../runtime/libasmrun.$(A) .
+	cd stdlib && $(LN_S) ../runtime/libasmrun.$(A) .
 stdlib/libcomprmarsh.$(A): runtime/libcomprmarsh.$(A)
-	cd stdlib; $(LN) ../runtime/libcomprmarsh.$(A) .
+	cd stdlib && $(LN_S) ../runtime/libcomprmarsh.$(A) .
 
 clean::
 	rm -f stdlib/libasmrun.a stdlib/libasmrun.lib
@@ -2689,9 +2689,9 @@ ifeq "$(INSTALL_BYTECODE_PROGRAMS)" "true"
 	  $(INSTALL_PROG) "tools/$$i$(EXE)" "$(INSTALL_BINDIR)/$$i.byte$(EXE)";\
 	  if test -f "tools/$$i".opt$(EXE); then \
 	    $(INSTALL_PROG) "tools/$$i.opt$(EXE)" "$(INSTALL_BINDIR)" && \
-	    (cd "$(INSTALL_BINDIR)" && $(LN) "$$i.opt$(EXE)" "$$i$(EXE)"); \
+	    (cd "$(INSTALL_BINDIR)" && $(LN_S) "$$i.opt$(EXE)" "$$i$(EXE)"); \
 	  else \
-	    (cd "$(INSTALL_BINDIR)" && $(LN) "$$i.byte$(EXE)" "$$i$(EXE)"); \
+	    (cd "$(INSTALL_BINDIR)" && $(LN_S) "$$i.byte$(EXE)" "$$i$(EXE)"); \
 	  fi; \
 	done
 else
@@ -2699,7 +2699,7 @@ else
 	do \
 	  if test -f "tools/$$i".opt$(EXE); then \
 	    $(INSTALL_PROG) "tools/$$i.opt$(EXE)" "$(INSTALL_BINDIR)"; \
-	    (cd "$(INSTALL_BINDIR)" && $(LN) "$$i.opt$(EXE)" "$$i$(EXE)"); \
+	    (cd "$(INSTALL_BINDIR)" && $(LN_S) "$$i.opt$(EXE)" "$$i$(EXE)"); \
 	  fi; \
 	done
 endif
@@ -2814,10 +2814,10 @@ endif # ifeq "$(BOOTSTRAPPING_FLEXDLL)" "true"
 ifeq "$(INSTALL_BYTECODE_PROGRAMS)" "true"
 	if test -f ocamlopt$(EXE); then $(MAKE) installopt; else \
 	   cd "$(INSTALL_BINDIR)"; \
-	   $(LN) ocamlc.byte$(EXE) ocamlc$(EXE); \
-	   $(LN) ocamllex.byte$(EXE) ocamllex$(EXE); \
+	   $(LN_S) ocamlc.byte$(EXE) ocamlc$(EXE); \
+	   $(LN_S) ocamllex.byte$(EXE) ocamllex$(EXE); \
 	   (test -f flexlink.byte$(EXE) && \
-	      $(LN) flexlink.byte$(EXE) flexlink$(EXE)) || true; \
+	      $(LN_S) flexlink.byte$(EXE) flexlink$(EXE)) || true; \
 	fi
 else
 	if test -f ocamlopt$(EXE); then $(MAKE) installopt; fi
@@ -2904,11 +2904,11 @@ endif
 ifeq "$(INSTALL_BYTECODE_PROGRAMS)" "true"
 	if test -f ocamlopt.opt$(EXE); then $(MAKE) installoptopt; else \
 	   cd "$(INSTALL_BINDIR)"; \
-	   $(LN) ocamlc.byte$(EXE) ocamlc$(EXE); \
-	   $(LN) ocamlopt.byte$(EXE) ocamlopt$(EXE); \
-	   $(LN) ocamllex.byte$(EXE) ocamllex$(EXE); \
+	   $(LN_S) ocamlc.byte$(EXE) ocamlc$(EXE); \
+	   $(LN_S) ocamlopt.byte$(EXE) ocamlopt$(EXE); \
+	   $(LN_S) ocamllex.byte$(EXE) ocamllex$(EXE); \
 	   (test -f flexlink.byte$(EXE) && \
-	     $(LN) flexlink.byte$(EXE) flexlink$(EXE)) || true; \
+	     $(LN_S) flexlink.byte$(EXE) flexlink$(EXE)) || true; \
 	fi
 else
 	if test -f ocamlopt.opt$(EXE); then $(MAKE) installoptopt; fi
@@ -2923,13 +2923,13 @@ installoptopt:
 	$(INSTALL_PROG) ocamlopt.opt$(EXE) "$(INSTALL_BINDIR)"
 	$(INSTALL_PROG) lex/ocamllex.opt$(EXE) "$(INSTALL_BINDIR)"
 	cd "$(INSTALL_BINDIR)"; \
-	   $(LN) ocamlc.opt$(EXE) ocamlc$(EXE); \
-	   $(LN) ocamlopt.opt$(EXE) ocamlopt$(EXE); \
-	   $(LN) ocamllex.opt$(EXE) ocamllex$(EXE)
+	   $(LN_S) ocamlc.opt$(EXE) ocamlc$(EXE); \
+	   $(LN_S) ocamlopt.opt$(EXE) ocamlopt$(EXE); \
+	   $(LN_S) ocamllex.opt$(EXE) ocamllex$(EXE)
 ifeq "$(BOOTSTRAPPING_FLEXDLL)" "true"
 	$(INSTALL_PROG) flexlink.opt$(EXE) "$(INSTALL_BINDIR)"
 	cd "$(INSTALL_BINDIR)"; \
-	  $(LN) flexlink.opt$(EXE) flexlink$(EXE)
+	  $(LN_S) flexlink.opt$(EXE) flexlink$(EXE)
 endif
 	$(INSTALL_DATA) \
 	   utils/*.cmx parsing/*.cmx typing/*.cmx bytecomp/*.cmx \

--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -167,7 +167,7 @@ OC_NATIVE_COMPFLAGS = @oc_native_compflags@
 OC_NATIVE_LINKFLAGS = -g
 
 # Platform-dependent command to create symbolic links
-LN = @ln@
+LN_S = @LN_S@
 
 # Platform-dependent assembler files to use to build the runtime
 runtime_ASM_OBJECTS = $(addprefix runtime/,@runtime_asm_objects@)

--- a/Makefile.common
+++ b/Makefile.common
@@ -467,3 +467,12 @@ endef # INSTALL_STRIPPED_BYTE_PROG
 # boot/ as part of coldstart. See read_runtime_launch_info in
 # bytecomp/bytelink.ml for further details.
 HEADER_NAME = runtime-launch-info
+
+ifeq "$(UNIX_OR_WIN32)" "win32"
+# Ensure that no command can create Cygwin symbolic links by ensuring that
+# symlink(2) will fail if native NTFS symlinks aren't available.
+export CYGWIN := $(strip \
+  $(filter-out winsymlinks winsymlinks:%, $(CYGWIN)) winsymlinks:nativestrict)
+export MSYS := $(strip \
+  $(filter-out winsymlinks winsymlinks:%, $(MSYS)) winsymlinks:nativestrict)
+endif

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -546,15 +546,11 @@ AC_DEFUN([OCAML_CC_SUPPORTS_LABELS_AS_VALUES], [
 
 AC_DEFUN([OCAML_CHECK_LN_ON_WINDOWS], [
   AC_MSG_CHECKING([for a workable solution for ln -sf])
-  ln -sf configure conftestLink
-  AS_IF([test -z "$(cmd /c dir conftestLink 2>/dev/null | grep -F SYMLINK)"],
-    [rm -f conftestLink
-    CYGWIN=winsymlinks:native ln -sf configure conftestLink
-    AS_IF([test -z "$(cmd /c dir conftestLink 2>/dev/null | grep -F SYMLINK)"],
-      [ln='cp -pf'],
-      [ln='CYGWIN=winsymlinks:native ln -sf']
-    )],
-    [ln='ln -sf']
+  AS_IF([m4_normalize(MSYS=winsymlinks:nativestrict
+                      CYGWIN=winsymlinks:nativestrict
+                      ln -sf configure conftestLink 2>/dev/null)],
+    [ln='ln -sf'],
+    [ln='cp -pf']
   )
   AC_MSG_RESULT([$ln])
 ])

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -543,3 +543,18 @@ AC_DEFUN([OCAML_CC_SUPPORTS_LABELS_AS_VALUES], [
       [Define if the C compiler supports the labels as values extension.])
   fi
 ])
+
+AC_DEFUN([OCAML_CHECK_LN_ON_WINDOWS], [
+  AC_MSG_CHECKING([for a workable solution for ln -sf])
+  ln -sf configure conftestLink
+  AS_IF([test -z "$(cmd /c dir conftestLink 2>/dev/null | grep -F SYMLINK)"],
+    [rm -f conftestLink
+    CYGWIN=winsymlinks:native ln -sf configure conftestLink
+    AS_IF([test -z "$(cmd /c dir conftestLink 2>/dev/null | grep -F SYMLINK)"],
+      [ln='cp -pf'],
+      [ln='CYGWIN=winsymlinks:native ln -sf']
+    )],
+    [ln='ln -sf']
+  )
+  AC_MSG_RESULT([$ln])
+])

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -544,13 +544,14 @@ AC_DEFUN([OCAML_CC_SUPPORTS_LABELS_AS_VALUES], [
   fi
 ])
 
-AC_DEFUN([OCAML_CHECK_LN_ON_WINDOWS], [
+AC_DEFUN([OCAML_PROG_LN_S_ON_WINDOWS], [
   AC_MSG_CHECKING([for a workable solution for ln -sf])
-  AS_IF([m4_normalize(MSYS=winsymlinks:nativestrict
-                      CYGWIN=winsymlinks:nativestrict
-                      ln -sf configure conftestLink 2>/dev/null)],
-    [ln='ln -sf'],
-    [ln='cp -pf']
-  )
-  AC_MSG_RESULT([$ln])
+  if MSYS=winsymlinks:nativestrict CYGWIN=winsymlinks:nativestrict \
+      ln -s configure conftestLink 2>/dev/null; then
+    ocaml_ln_s='ln -sf'
+  else
+    ocaml_ln_s='cp -pRf'
+  fi
+  rm -rf conftestLink
+  AC_MSG_RESULT([$ocaml_ln_s])
 ])

--- a/configure
+++ b/configure
@@ -13834,20 +13834,11 @@ case $host in #(
 
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for a workable solution for ln -sf" >&5
 printf %s "checking for a workable solution for ln -sf... " >&6; }
-  ln -sf configure conftestLink
-  if test -z "$(cmd /c dir conftestLink 2>/dev/null | grep -F SYMLINK)"
+  if MSYS=winsymlinks:nativestrict CYGWIN=winsymlinks:nativestrict ln -sf configure conftestLink 2>/dev/null
 then :
-  rm -f conftestLink
-    CYGWIN=winsymlinks:native ln -sf configure conftestLink
-    if test -z "$(cmd /c dir conftestLink 2>/dev/null | grep -F SYMLINK)"
-then :
-  ln='cp -pf'
-else $as_nop
-  ln='CYGWIN=winsymlinks:native ln -sf'
-
-fi
-else $as_nop
   ln='ln -sf'
+else $as_nop
+  ln='cp -pf'
 
 fi
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ln" >&5

--- a/configure
+++ b/configure
@@ -13831,7 +13831,28 @@ esac
 case $host in #(
   *-*-mingw32*|*-pc-windows) :
     unix_or_win32="win32"
-    ln='cp -pf'
+
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for a workable solution for ln -sf" >&5
+printf %s "checking for a workable solution for ln -sf... " >&6; }
+  ln -sf configure conftestLink
+  if test -z "$(cmd /c dir conftestLink 2>/dev/null | grep -F SYMLINK)"
+then :
+  rm -f conftestLink
+    CYGWIN=winsymlinks:native ln -sf configure conftestLink
+    if test -z "$(cmd /c dir conftestLink 2>/dev/null | grep -F SYMLINK)"
+then :
+  ln='cp -pf'
+else $as_nop
+  ln='CYGWIN=winsymlinks:native ln -sf'
+
+fi
+else $as_nop
+  ln='ln -sf'
+
+fi
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ln" >&5
+printf "%s\n" "$ln" >&6; }
+
     ocamltest_libunix="Some false"
     ocamlsrcdir="$(LC_ALL=C.UTF-8 cygpath -w -- "$ocamlsrcdir")"
     ocamlyacc_wstr_module="yacc/wstr" ;; #(

--- a/configure
+++ b/configure
@@ -888,7 +888,6 @@ syslib
 outputobj
 outputexe
 ocamlyacc_wstr_module
-ln
 unix_or_win32
 ocamlsrcdir
 systhread_support
@@ -3392,7 +3391,6 @@ LINEAR_MAGIC_NUMBER=Caml1999L035
 # Note: This is present for the flexdll bootstrap where it exposed as the old
 # TOOLPREF variable. It would be better if flexdll where updated to require
 # WINDRES instead.
-
 
 
 
@@ -13834,22 +13832,23 @@ case $host in #(
 
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for a workable solution for ln -sf" >&5
 printf %s "checking for a workable solution for ln -sf... " >&6; }
-  if MSYS=winsymlinks:nativestrict CYGWIN=winsymlinks:nativestrict ln -sf configure conftestLink 2>/dev/null
-then :
-  ln='ln -sf'
-else $as_nop
-  ln='cp -pf'
+  if MSYS=winsymlinks:nativestrict CYGWIN=winsymlinks:nativestrict \
+      ln -s configure conftestLink 2>/dev/null; then
+    ocaml_ln_s='ln -sf'
+  else
+    ocaml_ln_s='cp -pRf'
+  fi
+  rm -rf conftestLink
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ocaml_ln_s" >&5
+printf "%s\n" "$ocaml_ln_s" >&6; }
 
-fi
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ln" >&5
-printf "%s\n" "$ln" >&6; }
-
+    LN_S="$ocaml_ln_s"
     ocamltest_libunix="Some false"
     ocamlsrcdir="$(LC_ALL=C.UTF-8 cygpath -w -- "$ocamlsrcdir")"
     ocamlyacc_wstr_module="yacc/wstr" ;; #(
   *) :
     unix_or_win32="unix"
-  ln='ln -sf'
+  LN_S='ln -sf'
   ocamltest_libunix="Some true"
   ocamlyacc_wstr_module="" ;;
 esac

--- a/configure.ac
+++ b/configure.ac
@@ -726,7 +726,7 @@ AS_CASE([$lt_cv_ar_at_file],
 AS_CASE([$host],
   [*-*-mingw32*|*-pc-windows],
     [unix_or_win32="win32"
-    ln='cp -pf'
+    OCAML_CHECK_LN_ON_WINDOWS
     ocamltest_libunix="Some false"
     ocamlsrcdir="$(LC_ALL=C.UTF-8 cygpath -w -- "$ocamlsrcdir")"
     ocamlyacc_wstr_module="yacc/wstr"],

--- a/configure.ac
+++ b/configure.ac
@@ -151,7 +151,6 @@ AC_SUBST([oc_native_cppflags])
 AC_SUBST([systhread_support])
 AC_SUBST([ocamlsrcdir])
 AC_SUBST([unix_or_win32])
-AC_SUBST([ln])
 AC_SUBST([ocamlyacc_wstr_module])
 AC_SUBST([outputexe])
 AC_SUBST([outputobj])
@@ -726,12 +725,13 @@ AS_CASE([$lt_cv_ar_at_file],
 AS_CASE([$host],
   [*-*-mingw32*|*-pc-windows],
     [unix_or_win32="win32"
-    OCAML_CHECK_LN_ON_WINDOWS
+    OCAML_PROG_LN_S_ON_WINDOWS
+    LN_S="$ocaml_ln_s"
     ocamltest_libunix="Some false"
     ocamlsrcdir="$(LC_ALL=C.UTF-8 cygpath -w -- "$ocamlsrcdir")"
     ocamlyacc_wstr_module="yacc/wstr"],
   [unix_or_win32="unix"
-  ln='ln -sf'
+  LN_S='ln -sf'
   ocamltest_libunix="Some true"
   ocamlyacc_wstr_module=""])
 


### PR DESCRIPTION
Macro: AC_PROG_LN_S
https://www.gnu.org/software/autoconf/manual/autoconf-2.72/html_node/Particular-Programs.html#index-AC_005fPROG_005fLN_005fS-1

If `ln -s` doesn't work, Autoconf defaults to `cp -pR`.

> Symbolic links are not available on some systems; use ‘$(LN_S)’ as a
> portable substitute.

For both cp and ln:

> The -f option is portable nowadays.

https://www.gnu.org/software/autoconf/manual/autoconf-2.72/html_node/Limitations-of-Usual-Tools.html