### PR TITLE
Annotate more `caml_stat_*` functions

### DIFF
--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -171,6 +171,7 @@ CAMLextern wchar_t* caml_stat_wcsdup_noexc(const wchar_t *s);
    [*out_size]. This function is the "dummy" Unix implementation of the
    Windows-only functions caml_stat_char_array_{to,from}_utf16.
 */
+CAMLmalloc(caml_stat_free, 1, 2) CAMLreturns_nonnull()
 CAMLextern caml_stat_string caml_stat_memdup(const char *s, asize_t size,
                                              asize_t *out_size);
 

--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -174,6 +174,7 @@ extern unsigned short caml_win32_revision;
 
    If allocation fails, this returns NULL.
 */
+CAMLalloc(caml_stat_free, 1)
 CAMLextern wchar_t* caml_stat_strdup_noexc_to_utf16(const char *s);
 
 /* [caml_stat_strdup_to_utf16(s)] returns a null-terminated copy of [s],
@@ -186,6 +187,7 @@ CAMLextern wchar_t* caml_stat_strdup_noexc_to_utf16(const char *s);
 
    If allocation fails, this raises Out_of_memory.
 */
+CAMLalloc(caml_stat_free, 1) CAMLreturns_nonnull()
 CAMLextern wchar_t* caml_stat_strdup_to_utf16(const char *s);
 
 /* [caml_stat_strdup_noexc_of_utf16(s)] returns a null-terminated copy of [s],
@@ -197,6 +199,7 @@ CAMLextern wchar_t* caml_stat_strdup_to_utf16(const char *s);
 
    If allocation fails, this returns NULL.
 */
+CAMLalloc(caml_stat_free, 1)
 CAMLextern char* caml_stat_strdup_noexc_of_utf16(const wchar_t *s);
 
 /* [caml_stat_strdup_of_utf16(s)] returns a null-terminated copy of [s],
@@ -208,6 +211,7 @@ CAMLextern char* caml_stat_strdup_noexc_of_utf16(const wchar_t *s);
 
    If allocation fails, this raises Out_of_memory.
 */
+CAMLalloc(caml_stat_free, 1) CAMLreturns_nonnull()
 CAMLextern char* caml_stat_strdup_of_utf16(const wchar_t *s);
 
 /* [caml_stat_char_array_to_utf16(s, size, &out_size)] returns a copy of the
@@ -220,6 +224,7 @@ CAMLextern char* caml_stat_strdup_of_utf16(const wchar_t *s);
    The returned buffer is allocated with [caml_stat_alloc], so it should be
    freed using [caml_stat_free].
 */
+CAMLmalloc(caml_stat_free, 1, 2) CAMLreturns_nonnull()
 CAMLextern wchar_t *caml_stat_char_array_to_utf16(const char *s, size_t size,
                                                   size_t *out_size);
 
@@ -232,6 +237,7 @@ CAMLextern wchar_t *caml_stat_char_array_to_utf16(const char *s, size_t size,
    The returned buffer is allocated with [caml_stat_alloc], so it should be
    freed using [caml_stat_free].
 */
+CAMLalloc(caml_stat_free, 1) CAMLreturns_nonnull()
 CAMLextern char *caml_stat_char_array_of_utf16(const wchar_t *s, size_t size,
                                                size_t *out_size);
 


### PR DESCRIPTION
The `alloc_size` attributes indicates a size in bytes and cannot be used with a parameter describing the number of `wchar_t` in a wide-character buffer.