### PR TITLE
Stop using Sys.os_type in the codebase

### DIFF
--- a/bytecomp/bytelink.ml
+++ b/bytecomp/bytelink.ml
@@ -750,10 +750,12 @@ let append_bytecode bytecode_name exec_name =
    our back. *)
 
 let fix_exec_name name =
-  match Sys.os_type with
-    "Win32" | "Cygwin" ->
-      if String.contains name '.' then name else name ^ ".exe"
-  | _ -> name
+  (* We're predicting the behaviour of the C compiler here, which we assume
+     behaves in a host-like, not target-like fashion *)
+  if not Sys.win32 && not Sys.cygwin || String.contains name '.' then
+    name
+  else
+    name ^ ".exe"
 
 (* Main entry point (build a custom runtime if needed) *)
 

--- a/configure
+++ b/configure
@@ -3332,6 +3332,7 @@ tsan_ldflags="-fsanitize=thread"
 CSC=""
 CSCFLAGS=""
 
+# ostype *must* be of "Unix", "Win32", or "Cygwin"
 ostype="Unix"
 SO="so"
 toolchain="cc"

--- a/configure.ac
+++ b/configure.ac
@@ -64,6 +64,7 @@ tsan_ldflags="-fsanitize=thread"
 CSC=""
 CSCFLAGS=""
 
+# ostype *must* be of "Unix", "Win32", or "Cygwin"
 ostype="Unix"
 SO="so"
 toolchain="cc"

--- a/debugger/command_line.ml
+++ b/debugger/command_line.ml
@@ -79,11 +79,8 @@ let error text =
   raise Toplevel
 
 let check_not_windows feature =
-  match Sys.os_type with
-  | "Win32" ->
-      error ("\'"^feature^"\' feature not supported on Windows")
-  | _ ->
-      ()
+  if Sys.win32 then
+    error ("\'"^feature^"\' feature not supported on Windows")
 
 let eol =
   end_of_line Lexer.lexeme

--- a/debugger/debugcom.ml
+++ b/debugger/debugcom.ml
@@ -162,13 +162,12 @@ let rec do_go n =
 (* Perform a checkpoint *)
 
 let do_checkpoint () =
-  match Sys.os_type with
-    "Win32" -> failwith "do_checkpoint"
-  | _ ->
-      output_char !conn.io_out 'c';
-      flush !conn.io_out;
-      let pid = input_binary_int !conn.io_in in
-      if pid = -1 then Checkpoint_failed else Checkpoint_done pid
+  if Sys.win32 then
+    failwith "do_checkpoint";
+  output_char !conn.io_out 'c';
+  flush !conn.io_out;
+  let pid = input_binary_int !conn.io_in in
+  if pid = -1 then Checkpoint_failed else Checkpoint_done pid
 
 (* Kill the given process. *)
 let stop chan =

--- a/debugger/debugger_config.ml
+++ b/debugger/debugger_config.ml
@@ -53,9 +53,10 @@ let event_mark_after  = "<|a|>"
 
 (* Name of shell used to launch the debuggee *)
 let shell =
-  match Sys.os_type with
-    "Win32" -> "cmd"
-  | _ -> "/bin/sh"
+  if Sys.win32 then
+    "cmd"
+  else
+    "/bin/sh"
 
 (* Name of the OCaml runtime. *)
 let runtime_program = "ocamlrun"
@@ -77,10 +78,7 @@ let checkpoint_small_step = ref (~~ "1000")
 let checkpoint_max_count = ref 15
 
 (* Whether to keep checkpoints or not. *)
-let make_checkpoints = ref
-  (match Sys.os_type with
-    "Win32" -> false
-  | _ -> true)
+let make_checkpoints = ref (not Sys.win32)
 
 (* Whether to break when new code is loaded. *)
 let break_on_load = ref true

--- a/debugger/exec.ml
+++ b/debugger/exec.ml
@@ -25,12 +25,11 @@ let break _signum =
   then interrupted := true
   else raise Sys.Break
 
-let _ =
-  match Sys.os_type with
-    "Win32" -> ()
-  | _ ->
-      Sys.set_signal Sys.sigint (Sys.Signal_handle break);
-      Sys.set_signal Sys.sigpipe (Sys.Signal_handle(fun _ -> raise End_of_file))
+let () =
+  if not Sys.win32 then begin
+    Sys.set_signal Sys.sigint (Sys.Signal_handle break);
+    Sys.set_signal Sys.sigpipe (Sys.Signal_handle(fun _ -> raise End_of_file))
+  end
 
 let protect f =
   if !is_protected then

--- a/debugger/main.ml
+++ b/debugger/main.ml
@@ -204,13 +204,13 @@ let main () =
   Callback.register "Debugger.function_placeholder" function_placeholder;
   try
     socket_name :=
-      (match Sys.os_type with
-        "Win32" ->
-          (Unix.string_of_inet_addr Unix.inet_addr_loopback)^
-          ":"^
-          (Int.to_string (10000 + ((Unix.getpid ()) mod 10000)))
-      | _ -> Filename.concat (Filename.get_temp_dir_name ())
-                                ("camldebug" ^ (Int.to_string (Unix.getpid ())))
+      (if Sys.win32 then
+         (Unix.string_of_inet_addr Unix.inet_addr_loopback)^
+         ":"^
+         (Int.to_string (10000 + ((Unix.getpid ()) mod 10000)))
+       else
+         Filename.concat (Filename.get_temp_dir_name ())
+                            ("camldebug" ^ (Int.to_string (Unix.getpid ())));
       );
     begin try
       Arg.parse speclist anonymous usage;

--- a/debugger/program_loading.ml
+++ b/debugger/program_loading.ml
@@ -110,52 +110,51 @@ let generic_exec_win cmdline = function () ->
     raise Toplevel
 
 let generic_exec =
-  match Sys.os_type with
-    "Win32" -> generic_exec_win
-  | _ -> generic_exec_unix
+  if Sys.win32 then
+    generic_exec_win
+  else
+    generic_exec_unix
 
 (* Execute the program by calling the runtime explicitly *)
 let exec_with_runtime =
   generic_exec
     (function () ->
-      match Sys.os_type with
-        "Win32" ->
-          (* This would fail on a file name with spaces
-             but quoting is even worse because Unix.create_process
-             thinks each command line parameter is a file.
-             So no good solution so far *)
-          Printf.sprintf "%sset CAML_DEBUG_SOCKET=%s& %s %s %s"
-                     (get_win32_environment ())
-                     !socket_name
-                     runtime_program
-                     !program_name
-                     !arguments
-      | _ ->
-          Printf.sprintf "%sCAML_DEBUG_SOCKET=%s %s %s %s"
-                     (get_unix_environment ())
-                     !socket_name
-                     (Filename.quote runtime_program)
-                     (Filename.quote !program_name)
-                     !arguments)
+      if Sys.win32 then
+        (* This would fail on a file name with spaces but quoting is even worse
+           because Unix.create_process thinks each command line parameter is a
+           file.
+           So no good solution so far *)
+        Printf.sprintf "%sset CAML_DEBUG_SOCKET=%s& %s %s %s"
+                       (get_win32_environment ())
+                       !socket_name
+                       runtime_program
+                       !program_name
+                       !arguments
+      else
+        Printf.sprintf "%sCAML_DEBUG_SOCKET=%s %s %s %s"
+                       (get_unix_environment ())
+                       !socket_name
+                       (Filename.quote runtime_program)
+                       (Filename.quote !program_name)
+                       !arguments)
 
 (* Execute the program directly *)
 let exec_direct =
   generic_exec
     (function () ->
-      match Sys.os_type with
-        "Win32" ->
-          (* See the comment above *)
-          Printf.sprintf "%sset CAML_DEBUG_SOCKET=%s& %s %s"
-                     (get_win32_environment ())
-                     !socket_name
-                     !program_name
-                     !arguments
-      | _ ->
-          Printf.sprintf "%sCAML_DEBUG_SOCKET=%s %s %s"
-                     (get_unix_environment ())
-                     !socket_name
-                     (Filename.quote !program_name)
-                     !arguments)
+      if Sys.win32 then
+        (* See the comment above *)
+        Printf.sprintf "%sset CAML_DEBUG_SOCKET=%s& %s %s"
+                       (get_win32_environment ())
+                       !socket_name
+                       !program_name
+                       !arguments
+      else
+        Printf.sprintf "%sCAML_DEBUG_SOCKET=%s %s %s"
+                       (get_unix_environment ())
+                       !socket_name
+                       (Filename.quote !program_name)
+                       !arguments)
 
 (* Ask the user. *)
 let exec_manual =

--- a/driver/makedepend.ml
+++ b/driver/makedepend.ml
@@ -55,11 +55,12 @@ end
 let prepend_to_list l e = l := e :: !l
 
 (* Fix path to use '/' as directory separator instead of '\'.
-   Only under Windows. *)
-let fix_slash s =
-  if Sys.os_type = "Unix" then s else begin
-    String.map (function '\\' -> '/' | c -> c) s
-  end
+   Only under Windows/Cygwin. *)
+let fix_slash =
+  if Sys.unix then
+    Fun.id
+  else
+    String.map (function '\\' -> '/' | c -> c)
 
 (* Since we reinitialize load_path after reading OCAMLCOMP,
   we must use a cache instead of calling Sys.readdir too often. *)

--- a/lex/common.ml
+++ b/lex/common.ml
@@ -66,9 +66,10 @@ let copy_chars_win32 ic oc start stop =
   done
 
 let copy_chars =
-  match Sys.os_type with
-    "Win32" | "Cygwin" -> copy_chars_win32
-  | _       -> copy_chars_unix
+  if Sys.win32 || Sys.cygwin then
+    copy_chars_win32
+  else
+    copy_chars_unix
 
 let copy_chunk ic oc trl loc add_parens =
   if loc.start_pos < loc.end_pos || add_parens then begin

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -20,7 +20,7 @@
 #undef OCAML_OS_TYPE
 /* #define OCAML_OS_TYPE "Unix" */
 /* #define OCAML_OS_TYPE "Win32" */
-/* #define OCAML_OS_TYPE "MacOS" */
+/* #define OCAML_OS_TYPE "Cygwin" */
 
 /* 1. For the runtime system. */
 

--- a/stdlib/filename.ml
+++ b/stdlib/filename.ml
@@ -286,10 +286,12 @@ module Cygwin : SYSDEPS = struct
 end
 
 module Sysdeps =
-  (val (match Sys.os_type with
-       | "Win32" -> (module Win32: SYSDEPS)
-       | "Cygwin" -> (module Cygwin: SYSDEPS)
-       | _ -> (module Unix: SYSDEPS)))
+  (val (if Sys.win32 then
+          (module Win32: SYSDEPS)
+        else if Sys.cygwin then
+          (module Cygwin: SYSDEPS)
+        else
+          (module Unix: SYSDEPS)))
 
 include Sysdeps
 

--- a/stdlib/sys.mli
+++ b/stdlib/sys.mli
@@ -138,7 +138,13 @@ val os_type : string
 (** Operating system currently executing the OCaml program. One of
 -  ["Unix"] (for all Unix versions, including Linux and Mac OS X),
 -  ["Win32"] (for MS-Windows, OCaml compiled with MSVC++ or MinGW-w64),
--  ["Cygwin"] (for MS-Windows, OCaml compiled with Cygwin). *)
+-  ["Cygwin"] (for MS-Windows, OCaml compiled with Cygwin).
+
+   There have been other possible values for this string in OCaml's history, but
+   these three possible values are now permanently fixed. It is recommended that
+   {!unix}, {!win32}, or {!cygwin} be used instead, to avoid the need for
+   string comparison.
+*)
 
 type backend_type =
   | Native

--- a/testsuite/tests/lib-filename/suffix.ml
+++ b/testsuite/tests/lib-filename/suffix.ml
@@ -13,7 +13,7 @@ let () =
     | None -> assert false
     | Some base -> assert (base ^ suffix = name)
   in
-  let win32 = Sys.os_type = "Win32" || Sys.os_type = "Cygwin" in
+  let win32 = Sys.win32 || Sys.cygwin in
   full_test ~suffix:".txt" "foo.txt";
   full_test ~suffix:"txt" "foo.txt";
   full_test ~suffix:"" "foo.txt";

--- a/testsuite/tests/lib-unix/common/cloexec.ml
+++ b/testsuite/tests/lib-unix/common/cloexec.ml
@@ -53,14 +53,15 @@
    Windows will not allocate to the OCaml runtime of fdstatus.exe *)
 
 let string_of_fd (fd: Unix.file_descr) : string =
-  match Sys.os_type with
-  | "Unix" | "Cygwin" ->  Int.to_string (Obj.magic fd : int)
-  | "Win32" ->
-      if Sys.word_size = 32 then
-        Int32.to_string (Obj.magic fd : int32)
-      else
-        Int64.to_string (Obj.magic fd : int64)
-  | _ -> assert false
+  if Sys.unix || Sys.cygwin then
+    Int.to_string (Obj.magic fd : int)
+  else if Sys.win32 then
+    if Sys.word_size = 32 then
+      Int32.to_string (Obj.magic fd : int32)
+    else
+      Int64.to_string (Obj.magic fd : int64)
+  else
+    assert false
 
 let status_checker = "fdstatus.exe"
 

--- a/tools/ocamlmklib.ml
+++ b/tools/ocamlmklib.ml
@@ -28,7 +28,7 @@ let mklib out files opts =
 (* PR#4783: under Windows, don't use absolute paths because we do
    not know where the binary distribution will be installed. *)
 let compiler_path name =
-  if Sys.os_type = "Win32" then name else Filename.concat Config.bindir name
+  if Sys.win32 then name else Filename.concat Config.bindir name
 
 let bytecode_objs = ref []  (* .cmo,.cma,.ml,.mli files to pass to ocamlc *)
 and native_objs = ref []    (* .cmx,.ml,.mli files to pass to ocamlopt *)
@@ -254,18 +254,19 @@ let prepostfix pre name post =
   let dir = Filename.dirname name in
   Filename.concat dir (pre ^ base ^ post)
 
-let transl_path s =
-  match Sys.os_type with
-    | "Win32" ->
-        let s = Bytes.of_string s in
-        let rec aux i =
-          if i = Bytes.length s || Bytes.get s i = ' ' then s
-          else begin
-            if Bytes.get s i = '/' then Bytes.set s i '\\';
-            aux (i + 1)
-          end
-        in Bytes.to_string (aux 0)
-    | _ -> s
+let transl_path =
+  if Sys.win32 then
+    fun s ->
+      let s = Bytes.of_string s in
+      let rec aux i =
+        if i = Bytes.length s || Bytes.get s i = ' ' then s
+        else begin
+          if Bytes.get s i = '/' then Bytes.set s i '\\';
+          aux (i + 1)
+        end
+      in Bytes.to_string (aux 0)
+  else
+    Fun.id
 
 let flexdll_dirs =
   let dirs =

--- a/tools/ocamlprof.ml
+++ b/tools/ocamlprof.ml
@@ -56,9 +56,10 @@ let copy_chars_win32 nchars =
   done
 
 let copy_chars =
-  match Sys.os_type with
-    "Win32" | "Cygwin" -> copy_chars_win32
-  | _       -> copy_chars_unix
+  if Sys.win32 || Sys.cygwin then
+    copy_chars_win32
+  else
+    copy_chars_unix
 
 let copy next =
   assert (next >= !cur_point);

--- a/utils/ccomp.ml
+++ b/utils/ccomp.ml
@@ -51,7 +51,7 @@ let quote_files ~response_files lst =
   let s = String.concat " " quoted in
   if response_files &&
   (String.length s >= 65536
-  || (String.length s >= 4096 && Sys.os_type = "Win32"))
+  || (String.length s >= 4096 && Sys.win32))
   then build_response_file quoted
   else s
 

--- a/utils/misc.ml
+++ b/utils/misc.ml
@@ -553,9 +553,10 @@ let expand_directory alt s =
   else s
 
 let path_separator =
-  match Sys.os_type with
-  | "Win32" -> ';'
-  | _ -> ':'
+  if Sys.win32 then
+    ';'
+  else
+    ':'
 
 let split_path_contents ?(sep = path_separator) = function
   | "" -> []


### PR DESCRIPTION
Part of under-pinning for adding `Config.target_win32`; but not urgent in the end...