### PR TITLE
Latest GHA image warnings checking

### DIFF
--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -83,6 +83,7 @@ jobs:
 
     strategy:
       matrix: ${{ fromJSON(needs.config.outputs.matrix) }}
+      fail-fast: true
 
     steps:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,7 @@ jobs:
             name: extra (debug)
           - id: debug-s4096
             name: extra (debug-s4096)
+      fail-fast: true
     steps:
       - name: Download Artifact
         uses: actions/download-artifact@v4
@@ -212,6 +213,7 @@ jobs:
     strategy:
       matrix:
         include: ${{ fromJSON(needs.config.outputs.jobs) }}
+      fail-fast: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/configure
+++ b/configure
@@ -15113,7 +15113,8 @@ case $ocaml_cc_vendor in #(
   msvc-*) :
     case $ocaml_cc_vendor in #(
   msvc-*-clang-*) :
-    cc_warnings='-W4 -Wno-unused-parameter -Wno-sign-compare -Wundef'
+    cc_warnings="-W4 -Wno-unused-parameter -Wno-sign-compare -Wundef \
+-Wno-cast-function-type-mismatch"
          warn_error_flag='-WX' ;; #(
   *) :
     cc_warnings='-W2'

--- a/configure.ac
+++ b/configure.ac
@@ -921,7 +921,8 @@ AS_CASE([$ocaml_cc_vendor],
   [msvc-*],
     [AS_CASE([$ocaml_cc_vendor],
       [msvc-*-clang-*],
-        [cc_warnings='-W4 -Wno-unused-parameter -Wno-sign-compare -Wundef'
+        [cc_warnings="-W4 -Wno-unused-parameter -Wno-sign-compare -Wundef \
+-Wno-cast-function-type-mismatch"
          warn_error_flag='-WX'],
       [cc_warnings='-W2'
        warn_error_flag='-WX -options:strict'])],

--- a/testsuite/tests/lib-bigarray-2/bigarrcstub.c
+++ b/testsuite/tests/lib-bigarray-2/bigarrcstub.c
@@ -42,9 +42,15 @@ void printtab(double tab[DIMX][DIMY])
 value c_filltab(value unit)
 {
   filltab();
-  // the (int)CAML_BA_... cast is intended to avoid a MSVC warning (C5287)
-  return caml_ba_alloc_dims((int)CAML_BA_FLOAT64 | CAML_BA_C_LAYOUT,
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(push)
+#pragma warning(disable : 5287)
+#endif
+  return caml_ba_alloc_dims(CAML_BA_FLOAT64 | CAML_BA_C_LAYOUT,
                             2, ctab, (intnat)DIMX, (intnat)DIMY);
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(pop)
+#endif
 }
 
 value c_printtab(value ba)

--- a/testsuite/tests/lib-bigarray-2/bigarrfstub.c
+++ b/testsuite/tests/lib-bigarray-2/bigarrfstub.c
@@ -24,9 +24,15 @@ extern float ftab_[];
 value fortran_filltab(value unit)
 {
   filltab_();
-  // the (int)CAML_BA_... cast is intended to avoid a MSVC warning (C5287)
-  return caml_ba_alloc_dims((int)CAML_BA_FLOAT32 | CAML_BA_FORTRAN_LAYOUT,
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(push)
+#pragma warning(disable : 5287)
+#endif
+  return caml_ba_alloc_dims(CAML_BA_FLOAT32 | CAML_BA_FORTRAN_LAYOUT,
                             2, ftab_, (intnat)8, (intnat)6);
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(pop)
+#endif
 }
 
 value fortran_printtab(value ba)

--- a/testsuite/tests/statmemprof/bigarray_stubs.c
+++ b/testsuite/tests/statmemprof/bigarray_stubs.c
@@ -5,21 +5,41 @@ static char buf[10000];
 value static_bigstring(value unit)
 {
   intnat dim[] = { sizeof(buf) };
-  // the (int) cast is intended to silence a MSVC warning (C5287)
-  return caml_ba_alloc((int)CAML_BA_UINT8 | CAML_BA_C_LAYOUT | CAML_BA_EXTERNAL,
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(push)
+#pragma warning(disable : 5287)
+#endif
+  return caml_ba_alloc(CAML_BA_UINT8 | CAML_BA_C_LAYOUT | CAML_BA_EXTERNAL,
                        1, buf, dim);
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(pop)
+#endif
 }
 
 value new_bigstring(value unit)
 {
   intnat dim[] = { 5000 };
-  return caml_ba_alloc((int)CAML_BA_UINT8 | CAML_BA_C_LAYOUT,
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(push)
+#pragma warning(disable : 5287)
+#endif
+  return caml_ba_alloc(CAML_BA_UINT8 | CAML_BA_C_LAYOUT,
                        1, NULL, dim);
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(pop)
+#endif
 }
 
 value malloc_bigstring(value unit)
 {
   intnat dim[] = { 5000 };
-  return caml_ba_alloc((int)CAML_BA_UINT8 | CAML_BA_C_LAYOUT | CAML_BA_MANAGED,
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(push)
+#pragma warning(disable : 5287)
+#endif
+  return caml_ba_alloc(CAML_BA_UINT8 | CAML_BA_C_LAYOUT | CAML_BA_MANAGED,
                        1, malloc(dim[0]), dim);
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(pop)
+#endif
 }


### PR DESCRIPTION
Notes:

Visual Studio 17.12.3 (msvc-1942-clang-18-1): tests both pass and x64 cl / clang-cl and i686 cl all build fine. cl 19.42.34435 / clang 18.1.8

Visual Studio 17.14.6 Preview 1.0 (msvc-1944-clang-19-1): repro test failures for i686/x64 and clang-cl build issue. cl 19.44.35211 / clang 19.1.5

Comment 3 Jun 2025 at https://developercommunity.visualstudio.com/t/warning-C5287:-operands-are-different-e/10877942#T-N10914938 - note that it's still marked "Fixed - Pending Release" rather than "Closed - Fixed" with, say, "Fixed In: Visual Studio 17.14.6" as a tag

xref 14097