### PR TITLE
[Relocatable] Follow-up 2: Move `caml_search_dll_in_path` to dynlink.c

### DIFF
--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -156,11 +156,13 @@ CAMLextern value caml_win32_get_temp_path(void);
 
 #define CAML_DIR_SEP T("\\")
 #define Is_separator(c) (c == '\\' || c == '/')
+#define EXT_DLL L".dll"
 
 #else
 
 #define CAML_DIR_SEP T("/")
 #define Is_separator(c) (c == '/')
+#define EXT_DLL ".so"
 
 #endif /* _WIN32 */
 

--- a/runtime/dynlink.c
+++ b/runtime/dynlink.c
@@ -229,6 +229,17 @@ CAMLprim value caml_dynlink_parse_ld_conf(value vstdlib)
 
 #ifndef NATIVE_CODE
 
+char_os * caml_search_dll_in_path(struct ext_table * path, const char_os * name)
+{
+  char_os * dllname;
+  char_os * res;
+
+  dllname = caml_stat_strconcat_os(2, name, EXT_DLL);
+  res = caml_search_in_path(path, dllname);
+  caml_stat_free(dllname);
+  return res;
+}
+
 /* Open the given shared library and add it to shared_libs.
    Abort on error. */
 static void open_shared_lib(char_os * name)

--- a/runtime/unix.c
+++ b/runtime/unix.c
@@ -219,18 +219,6 @@ caml_stat_string caml_search_exe_in_path(const char * name)
   return res;
 }
 
-caml_stat_string caml_search_dll_in_path(struct ext_table * path,
-                                         const char * name)
-{
-  caml_stat_string dllname;
-  caml_stat_string res;
-
-  dllname = caml_stat_strconcat(2, name, ".so");
-  res = caml_search_in_path(path, dllname);
-  caml_stat_free(dllname);
-  return res;
-}
-
 #ifdef WITH_DYNAMIC_LINKING
 #ifdef __CYGWIN__
 /* Use flexdll */

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -210,17 +210,6 @@ CAMLexport wchar_t * caml_search_exe_in_path(const wchar_t * name)
   }
 }
 
-wchar_t * caml_search_dll_in_path(struct ext_table * path, const wchar_t * name)
-{
-  wchar_t * dllname;
-  wchar_t * res;
-
-  dllname = caml_stat_wcsconcat(2, name, L".dll");
-  res = caml_search_in_path(path, dllname);
-  caml_stat_free(dllname);
-  return res;
-}
-
 #ifdef WITH_DYNAMIC_LINKING
 
 void * caml_dlopen(wchar_t * libname, int global)


### PR DESCRIPTION
Eliminates code duplication between unix.c and win32.c