### PR TITLE
[Relocatable] Follow-up 21: Remove unused `caml_cds_file`

### DIFF
--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -50,8 +50,6 @@
 /* The table of debug information fragments */
 struct ext_table caml_debug_info;
 
-CAMLexport char_os * caml_cds_file = NULL;
-
 /* Location of fields in the Instruct.debug_event record */
 enum {
   EV_POS = 0,

--- a/runtime/caml/backtrace.h
+++ b/runtime/caml/backtrace.h
@@ -111,9 +111,6 @@ CAMLextern void caml_record_backtraces(int);
 
 #ifndef NATIVE_CODE
 
-/* Path to the file containing debug information, if any, or NULL. */
-CAMLextern char_os * caml_cds_file;
-
 /* Primitive called _only_ by runtime to record unwinded frames to
  * backtrace.  A similar primitive exists for native code, but with a
  * different prototype. */


### PR DESCRIPTION
OCaml 4.x global which should have been removed with OCaml 5.0