### PR TITLE
[Relocatable] Follow-up 4: Remove unnecessary Cygwin path workarounds

### DIFF
--- a/runtime/unix.c
+++ b/runtime/unix.c
@@ -157,50 +157,6 @@ caml_stat_string caml_search_in_path(struct ext_table * path, const char * name)
   return caml_stat_strdup(name);
 }
 
-#ifdef __CYGWIN__
-
-/* Cygwin needs special treatment because of the implicit ".exe" at the
-   end of executable file names */
-
-static int cygwin_file_exists(const char * name)
-{
-  int fd, ret;
-  struct stat st;
-  /* Cannot use stat() here because it adds ".exe" implicitly */
-  fd = open(name, O_RDONLY);
-  if (fd == -1) return 0;
-  ret = fstat(fd, &st);
-  close(fd);
-  return ret == 0 && S_ISREG(st.st_mode);
-}
-
-static caml_stat_string cygwin_search_exe_in_path(struct ext_table * path,
-                                                  const char * name)
-{
-  char * dir, * fullname;
-  for (const char *p = name; *p != 0; p++) {
-    if (*p == '/' || *p == '\\') goto not_found;
-  }
-  for (int i = 0; i < path->size; i++) {
-    dir = path->contents[i];
-    if (dir[0] == 0) dir = ".";  /* empty path component = current dir */
-    fullname = caml_stat_strconcat(3, dir, "/", name);
-    if (cygwin_file_exists(fullname)) return fullname;
-    caml_stat_free(fullname);
-    fullname = caml_stat_strconcat(4, dir, "/", name, ".exe");
-    if (cygwin_file_exists(fullname)) return fullname;
-    caml_stat_free(fullname);
-  }
- not_found:
-  if (cygwin_file_exists(name)) return caml_stat_strdup(name);
-  fullname = caml_stat_strconcat(2, name, ".exe");
-  if (cygwin_file_exists(fullname)) return fullname;
-  caml_stat_free(fullname);
-  return caml_stat_strdup(name);
-}
-
-#endif
-
 caml_stat_string caml_search_exe_in_path(const char * name)
 {
   struct ext_table path;
@@ -209,11 +165,7 @@ caml_stat_string caml_search_exe_in_path(const char * name)
 
   caml_ext_table_init(&path, 8);
   tofree = caml_decompose_path(&path, getenv("PATH"));
-#ifndef __CYGWIN__
   res = caml_search_in_path(&path, name);
-#else
-  res = cygwin_search_exe_in_path(&path, name);
-#endif
   caml_stat_free(tofree);
   caml_ext_table_free(&path, 0);
   return res;

--- a/stdlib/header.c
+++ b/stdlib/header.c
@@ -180,10 +180,6 @@ typedef char ** argv_t;
 #define unsafe_copy(dst, src, dstsize) strcpy(dst, src)
 #endif
 
-#ifndef __CYGWIN__
-
-/* Normal Unix search path function */
-
 static char * searchpath(char * name)
 {
   static char fullname[PATH_MAX + 1];
@@ -210,56 +206,6 @@ static char * searchpath(char * name)
   }
   return fullname;
 }
-
-#else
-
-/* Special version for Cygwin32: takes care of the ".exe" implicit suffix */
-
-static int file_ok(char * name)
-{
-  int fd;
-  /* Cannot use stat() here because it adds ".exe" implicitly */
-  fd = open(name, O_RDONLY);
-  if (fd == -1) return 0;
-  close(fd);
-  return 1;
-}
-
-static char * searchpath(char * name)
-{
-  char * path, * fullname;
-
-  path = getenv("PATH");
-  fullname = malloc(strlen(name) + (path == NULL ? 0 : strlen(path)) + 6);
-  /* 6 = "/" plus ".exe" plus final "\0" */
-  if (fullname == NULL) return name;
-  /* Check for absolute path name */
-  for (char *p = name; *p != 0; p++) {
-    if (*p == '/' || *p == '\\') {
-      if (file_ok(name)) return name;
-      strcpy(fullname, name);
-      strcat(fullname, ".exe");
-      if (file_ok(fullname)) return fullname;
-      return name;
-    }
-  }
-  /* Search in path */
-  if (path == NULL) return name;
-  while(1) {
-    char * p;
-    for (p = fullname; *path != 0 && *path != ':'; p++, path++) *p = *path;
-    if (p != fullname) *p++ = '/';
-    strcpy(p, name);
-    if (file_ok(fullname)) return fullname;
-    strcat(fullname, ".exe");
-    if (file_ok(fullname)) return fullname;
-    if (*path == 0) break;
-    path++;
-  }
-  return name;
-}
-
-#endif
 
 NORETURN static void exit_with_error(const char *str1,
                                      const char *str2,


### PR DESCRIPTION
This is no longer required (nor does it work). Cygwin 1.5.20 (July 2006) added the transparent_exe option to the CYGWIN environment variable which made open behave in the same way as stat. Cygwin 1.7.1 (December 2009 and, despite the version number, the first release of Cygwin 1.7) made this behaviour default (and removed the ability to turn it off).