### PR TITLE
[Relocatable] Follow-up 9: Harden processing of `SOURCE_DATE_EPOCH` in ocamldoc

### DIFF
--- a/.depend
+++ b/.depend
@@ -9533,6 +9533,7 @@ ocamldoc/odoc_misc.cmo : \
     typing/path.cmi \
     ocamldoc/odoc_types.cmi \
     ocamldoc/odoc_messages.cmi \
+    ocamldoc/odoc_global.cmi \
     parsing/longident.cmi \
     typing/btype.cmi \
     ocamldoc/odoc_misc.cmi
@@ -9543,6 +9544,7 @@ ocamldoc/odoc_misc.cmx : \
     typing/path.cmx \
     ocamldoc/odoc_types.cmx \
     ocamldoc/odoc_messages.cmx \
+    ocamldoc/odoc_global.cmx \
     parsing/longident.cmx \
     typing/btype.cmx \
     ocamldoc/odoc_misc.cmi

--- a/ocamldoc/odoc_man.ml
+++ b/ocamldoc/odoc_man.ml
@@ -901,7 +901,7 @@ class man =
         let b = new_buf () in
         bs b (".TH \""^cl.cl_name^"\" ");
         bs b !man_section ;
-        bs b (" "^Odoc_misc.current_date^" ");
+        bs b (" "^Odoc_misc.current_date()^" ");
         bs b "OCamldoc ";
         bs b ("\""^(match !Global.title with Some t -> t | None -> "")^"\"\n");
 
@@ -959,7 +959,7 @@ class man =
         let b = new_buf () in
         bs b (".TH \""^ct.clt_name^"\" ");
         bs b !man_section ;
-        bs b (" "^Odoc_misc.current_date^" ");
+        bs b (" "^Odoc_misc.current_date()^" ");
         bs b "OCamldoc ";
         bs b ("\""^(match !Global.title with Some t -> t | None -> "")^"\"\n");
 
@@ -1051,7 +1051,7 @@ class man =
         let b = new_buf () in
         bs b (".TH \""^mt.mt_name^"\" ");
         bs b !man_section ;
-        bs b (" "^Odoc_misc.current_date^" ");
+        bs b (" "^Odoc_misc.current_date()^" ");
         bs b "OCamldoc ";
         bs b ("\""^(match !Global.title with Some t -> t | None -> "")^"\"\n");
 
@@ -1133,7 +1133,7 @@ class man =
         let b = new_buf () in
         bs b (".TH \""^m.m_name^"\" ");
         bs b !man_section ;
-        bs b (" "^Odoc_misc.current_date^" ");
+        bs b (" "^Odoc_misc.current_date()^" ");
         bs b "OCamldoc ";
         bs b ("\""^(match !Global.title with Some t -> t | None -> "")^"\"\n");
 
@@ -1239,7 +1239,7 @@ class man =
         let b = new_buf () in
         bs b (".TH \""^name^"\" ");
         bs b !man_section ;
-        bs b (" "^Odoc_misc.current_date^" ");
+        bs b (" "^Odoc_misc.current_date()^" ");
         bs b "OCamldoc ";
         bs b ("\""^(match !Global.title with Some t -> t | None -> "")^"\"\n");
         bs b ".SH NAME\n";

--- a/ocamldoc/odoc_misc.ml
+++ b/ocamldoc/odoc_misc.ml
@@ -247,14 +247,28 @@ let string_of_date ?(absolute=false) ?(hour=true) d =
      ""
   )
 
+let date_warning = ref (Fun.const ())
+
 let current_date =
   let time =
-    try
-      float_of_string (Sys.getenv "SOURCE_DATE_EPOCH")
-    with
-      Not_found -> Unix.time ()
+    match Sys.getenv_opt "SOURCE_DATE_EPOCH" with
+    | None -> Unix.time ()
+    | Some value ->
+        match Float.of_string_opt value with
+        | Some stamp -> stamp
+        | None ->
+            date_warning := (fun () ->
+              Odoc_global.pwarning
+                "The SOURCE_DATE_EPOCH environment variable could not be \
+                 parsed and has been ignored.";
+              date_warning := Fun.const ());
+            Unix.time ()
   in string_of_date ~absolute: true ~hour: false time
 
+let current_date () =
+  (* Displays a warning the first time this is called if SOURCE_DATE_EPOCH was
+     set but could not be parsed. *)
+  !date_warning (); current_date
 
 let rec text_list_concat sep l =
   match l with

--- a/ocamldoc/odoc_misc.mli
+++ b/ocamldoc/odoc_misc.mli
@@ -66,7 +66,7 @@ val string_of_date : ?absolute:bool -> ?hour:bool -> float -> string
 (* Value returned by string_of_date for current time.
  * Uses environment variable SOURCE_DATE_EPOCH if set; falls back to
  * current timestamp otherwise. *)
-val current_date : string
+val current_date : unit -> string
 
 (** Return the first sentence (until the first dot) of a text.
    Don't stop in the middle of [Code], [Verbatim], [List], [Lnum],


### PR DESCRIPTION
Previously, running:

SOURCE_DATE_EPOCH= ocamldoc

resulted in an uncaught Failure "float_of_string" exception. The processing of SOURCE_DATE_EPOCH is firstly hardened to cope with parsing errors and then a one-time warning is displayed the first time it's actually used (at present it's only required in Odoc_man).