### PR TITLE
[Relocatable] Follow-up 14: Fix C library options for win32unix

### DIFF
--- a/Changes
+++ b/Changes
@@ -243,6 +243,10 @@ Working version
   do so. (Fixes #14323)
   (Nicolás Ojeda Bär, review by Vincent Laviron)
 
+- #14???: Remove duplicated linker options from unix.cma and unix.cmxa on
+  Windows.
+  (David Allsopp, review by ???)
+
 ### Tools:
 
 - #14055: Invert BUILD_PATH_PREFIX_MAP in directories loaded at startup

--- a/otherlibs/Makefile.otherlibs.common
+++ b/otherlibs/Makefile.otherlibs.common
@@ -101,7 +101,7 @@ else
 endif
 
 $(LIBNAME).cmxs: $(LIBNAME).cmxa $(STUBSLIB_NATIVE)
-	$(V_OCAMLOPT)$(CAMLOPT) -shared -o $(LIBNAME).cmxs -I . $(LIBNAME).cmxa
+	$(V_OCAMLOPT)$(CAMLOPT) -shared -o $@ -I . $< $(addprefix -cclib , $(LDOPTS))
 
 lib$(CLIBNAME_BYTECODE).$(A): $(COBJS)
 	$(V_OCAMLMKLIB)$(MKLIB) -oc $(CLIBNAME_BYTECODE) $(COBJS_BYTECODE) $(LDOPTS)

--- a/otherlibs/unix/Makefile
+++ b/otherlibs/unix/Makefile
@@ -35,9 +35,7 @@ unixLabels.cmi: \
   EXTRACAMLFLAGS += -pp "$(AWK) -f $(ROOTDIR)/stdlib/expand_module_aliases.awk"
 
 ifeq "$(UNIX_OR_WIN32)" "win32"
-WIN32_LIBS=$(call SYSLIB,ws2_32) $(call SYSLIB,advapi32)
-LINKOPTS=$(addprefix -cclib ,$(WIN32_LIBS))
-LDOPTS=$(addprefix -ldopt ,$(WIN32_LIBS))
+LDOPTS=-lws2_32 -ladvapi32
 else # Unix
 # dllunix.so particularly requires libm for modf symbols
 LDOPTS=$(NATIVECCLIBS)

--- a/testsuite/tools/testLinkModes.ml
+++ b/testsuite/tools/testLinkModes.ml
@@ -552,11 +552,7 @@ let compile_test usr_bin_sh config env test test_program description =
             ~clibs:["-lcomprmarsh"; "-lunixnat"; Config.compression_c_libraries]
             ~linker_exit_code ["-output-obj"]
       | Output_complete_obj(C_ocamlc, Static) ->
-          (* At the moment, the partial linker will pass -lws2_32 and -ladvapi32
-             on to the partial linker on mingw-w64 which causes a failure. Until
-             this is fixed, pass the libraries manually, using -noautolink. *)
-          f ~clibs:[]
-            ["-output-complete-obj"; "-noautolink"; "-cclib"; "-lunixbyt"]
+          f ~clibs:[] ["-output-complete-obj"]
       | Output_complete_obj(C_ocamlc, Shared) ->
           (* The partial linker doesn't correctly process
              -runtime-variant _shared, as the .so gets passed to the partial


### PR DESCRIPTION
-lws2_32 and -ladvapi32 are already supplied by default, so they don't need to be in unix.cma/unix.cmxa. However, they do need to be passed when building unix.cmxs, and they were previously acquired via unix.cmxa. Tweak the way LDOPTS is used in Makefile.otherlibs.common (which now is only used for the unix library) so that it's correctly passed to both ocamlopt and ocamlmklib.