### PR TITLE
[Relocatable] Follow-up 15: Build and install `threads.cmxs`

### DIFF
--- a/Changes
+++ b/Changes
@@ -243,6 +243,9 @@ Working version
   do so. (Fixes #14323)
   (Nicolás Ojeda Bär, review by Vincent Laviron)
 
+- #14???: Build and install threads.cmxs.
+  (David Allsopp, review by ???)
+
 ### Tools:
 
 - #14055: Invert BUILD_PATH_PREFIX_MAP in directories loaded at startup

--- a/otherlibs/systhreads/Makefile
+++ b/otherlibs/systhreads/Makefile
@@ -45,9 +45,6 @@ LIBNAME=threads
 # That's why this dependency is handled in the Makefile directly
 # and removed from the output of the C compiler during make depend
 
-BYTECODE_C_OBJS=st_stubs.b.$(O)
-NATIVECODE_C_OBJS=st_stubs.n.$(O)
-
 THREADS_SOURCES = thread.ml event.ml
 
 THREADS_BCOBJS = $(THREADS_SOURCES:.ml=.cmo)
@@ -61,15 +58,20 @@ all: lib$(LIBNAME).$(A) $(LIBNAME).cma $(CMIFILES)
 
 allopt: lib$(LIBNAME)nat.$(A) $(LIBNAME).cmxa $(CMIFILES)
 
+ifeq "$(NATDYNLINK)" "true"
+allopt: $(LIBNAME).cmxs
+endif
+
 lib$(LIBNAME).$(A): OC_CFLAGS = $(OC_BYTECODE_CFLAGS)
 
-lib$(LIBNAME).$(A): $(BYTECODE_C_OBJS)
-	$(V_OCAMLMKLIB)$(MKLIB) -o $(LIBNAME) $(BYTECODE_C_OBJS)
+lib$(LIBNAME).$(A): st_stubs.b.$(O) st_stubs_shared.b.$(O)
+	@$(MKLIB) -o $(LIBNAME) st_stubs_shared.b.$(O)
+	$(V_OCAMLMKLIB)$(MKLIB) -custom -o $(LIBNAME) $<
 
 lib$(LIBNAME)nat.$(A): OC_CFLAGS = $(OC_NATIVE_CFLAGS)
 
-lib$(LIBNAME)nat.$(A): $(NATIVECODE_C_OBJS)
-	$(V_OCAMLMKLIB)$(MKLIB) -o $(LIBNAME)nat $^
+lib$(LIBNAME)nat.$(A): st_stubs.n.$(O)
+	$(V_OCAMLMKLIB)$(MKLIB) -custom -o $(LIBNAME)nat $^
 
 $(LIBNAME).cma: $(THREADS_BCOBJS)
 	$(V_OCAMLMKLIB)$(MKLIB) -o $(LIBNAME) -ocamlc '$(CAMLC)' -linkall $^
@@ -78,14 +80,20 @@ $(LIBNAME).cma: $(THREADS_BCOBJS)
 $(LIBNAME).cmxa: $(THREADS_NCOBJS)
 	$(V_LINKOPT)$(CAMLOPT) -linkall -a -cclib -lthreadsnat -o $@ $^
 
-# The following lines produce two object files st_stubs.b.$(O) and
-# st_stubs.n.$(O) from the same source file st_stubs.c (it is compiled
-# twice, each time with different options).
+st_stubs_shared.n.$(O): OC_CFLAGS = $(OC_NATIVE_CFLAGS)
+
+$(LIBNAME).cmxs: $(THREADS_NCOBJS) st_stubs_shared.n.$(O)
+	$(V_LINKOPT)$(CAMLOPT) -linkall -shared -o $@ $^
+
+# The following lines produce object files based on st_stubs.c. Four objects are
+# produced - a static and shared version in both bytecode and native versions.
+
+st_stubs_shared.%.$(O): OC_CPPFLAGS += -DSYSTHREADS_SHARED
 
 ifeq "$(COMPUTE_DEPS)" "true"
-st_stubs.%.$(O): st_stubs.c
+st_stubs%.$(O): st_stubs.c
 else
-st_stubs.%.$(O): st_stubs.c $(RUNTIME_HEADERS) $(wildcard *.h)
+st_stubs%.$(O): st_stubs.c $(RUNTIME_HEADERS) $(wildcard *.h)
 endif
 	$(V_CC)$(CC) $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) \
 	  $(OUTPUTOBJ)$@ -c $<
@@ -127,6 +135,9 @@ installopt:
 	$(INSTALL_DATA) \
 	  $(THREADS_NCOBJS) threads.cmxa threads.$(A) \
 	  "$(INSTALL_THREADSLIBDIR)"
+ifeq "$(NATDYNLINK)" "true"
+	$(INSTALL_PROG) $(LIBNAME).cmxs "$(INSTALL_THREADSLIBDIR)"
+endif
 
 %.cmi: %.mli
 	$(V_OCAMLC)$(CAMLC) -c $(COMPFLAGS) $<

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -19,16 +19,13 @@
    any reason. In mingw-w64 13.0.0, a subtle change meant that time.h causes
    pthread_compat.h to be read. For this reason, this next block must appear
    before anything headers are included. */
-#if defined(_WIN32) && !defined(NATIVE_CODE) && !defined(_MSC_VER)
+#if defined(_WIN32) && defined(SYSTHREADS_SHARED)
 /* Ensure that pthread.h marks symbols __declspec(dllimport) so that they can be
    picked up from the runtime (which will have linked winpthreads statically).
    mingw-w64 11.0.0 introduced WINPTHREADS_USE_DLLIMPORT to do this explicitly;
    prior versions co-opted this on the internal DLL_EXPORT, but this is ignored
    in 11.0 and later unless IN_WINPTHREAD is also defined, so we can safely
-   define both to support both versions.
-   When compiling with MSVC, we currently link directly the winpthreads objects
-   into our runtime, so we do not want to mark its symbols with
-   __declspec(dllimport). */
+   define both to support both versions. */
 #define WINPTHREADS_USE_DLLIMPORT
 #define DLL_EXPORT
 #endif

--- a/testsuite/tools/testDynlink.ml
+++ b/testsuite/tools/testDynlink.ml
@@ -124,19 +124,6 @@ let () =
       Harness.fail_because "%s is expected to return with exit code %d"
                            test_program expected_exit_code;
   in
-  let test_libraries_in_prog ?expected_exit_code env libraries =
-    if mode = Native && List.mem "threads" libraries then
-      (* cf. ocaml/ocaml#12250 - no threads.cmxs *)
-      let threads_plugin =
-        Environment.in_libdir env (Filename.concat "threads" "threads.cmxs")
-      in
-      if Sys.file_exists threads_plugin then
-        Harness.fail_because "threads.cmxs is not expected to exist"
-      else
-        ()
-    else
-      test_libraries_in_prog ?expected_exit_code env libraries
-  in
   let not_dynlink l = not (List.mem "dynlink" l) in
   let files, re_compile = compile_test_program () in
   let expected_exit_code =

--- a/testsuite/tools/testToplevel.ml
+++ b/testsuite/tools/testToplevel.ml
@@ -34,27 +34,6 @@ let run config env mode =
                     (* dynlink.cmxs does not exist, for obvious reasons, but we
                        can check loading the library in ocamlnat "works". *)
                     "cmxa"
-                  else if library = "threads" then
-                    let threads_plugin =
-                      let plugin = Filename.concat "threads" "threads.cmxs" in
-                      Environment.in_libdir env plugin
-                    in
-                    if Sys.file_exists threads_plugin then
-                      Harness.fail_because
-                        "threads.cmxs is not expected to exist"
-                    else if Sys.win32 then
-                      (* cf. note in ocaml/ocaml#13520 - threads.cmxa is
-                         correctly compiled assuming winpthreads is statically
-                         in the same image (so without defining
-                         WINPTHREADS_USE_DLLIMPORT), but this is incorrect for
-                         threads.cmxs, as threads.cmxs may load more than 2GiB
-                         away from the main executable. For native Windows, it's
-                         not possible to rely on ocamlnat's automatic
-                         cmxa -> cmxs recompilation. *)
-                      "cmxs"
-                    else
-                      (* cf. ocaml/ocaml#12250 - no threads.cmxs *)
-                      "cmxa"
                   else
                     "cmxs"
               | Bytecode ->
@@ -78,11 +57,8 @@ let run config env mode =
       (* Systems configured with --disable-shared can't load bytecode libraries
          which need C stubs *)
       if Sys.cygwin && mode = Native && List.mem "unix" libraries
-      || Sys.win32 && mode = Native && List.mem "threads" libraries
       || has_c_stubs && not Config.supports_shared_libraries then
-        (* cf. ocaml/flexdll#146 - Cygwin's ocamlnat can't load unix.cmxs and
-           the lines above will have triggered native Windows being unable to
-           load threads.cmxs *)
+        (* cf. ocaml/flexdll#146 - Cygwin's ocamlnat can't load unix.cmxs *)
         125
       else
         0


### PR DESCRIPTION
Crucially, the corrects the flags used for creating a DLL on Windows, allowing threads.cmxs to be loaded in ocamlnat.