### PR TITLE
[Relocatable] Follow-up 17: Use entrypoint flexdll branch

### DIFF
--- a/testsuite/tools/testDynlink.ml
+++ b/testsuite/tools/testDynlink.ml
@@ -107,10 +107,7 @@ let () =
       | None ->
           (* Systems configured with --disable-shared can't load bytecode
              libraries which need C stubs *)
-          if (Sys.cygwin && mode = Native && List.mem "unix" libraries)
-             || (not Config.supports_shared_libraries && has_c_stubs) then
-            (* cf. ocaml/flexdll#146 - Cygwin's natdynlink can't load
-                   unix.cmxs *)
+          if not Config.supports_shared_libraries && has_c_stubs then
             2
           else
             0

--- a/testsuite/tools/testToplevel.ml
+++ b/testsuite/tools/testToplevel.ml
@@ -77,11 +77,9 @@ let run config env mode =
     let expected_exit_code =
       (* Systems configured with --disable-shared can't load bytecode libraries
          which need C stubs *)
-      if Sys.cygwin && mode = Native && List.mem "unix" libraries
-      || Sys.win32 && mode = Native && List.mem "threads" libraries
+      if Sys.win32 && mode = Native && List.mem "threads" libraries
       || has_c_stubs && not Config.supports_shared_libraries then
-        (* cf. ocaml/flexdll#146 - Cygwin's ocamlnat can't load unix.cmxs and
-           the lines above will have triggered native Windows being unable to
+        (* The lines above will have triggered native Windows being unable to
            load threads.cmxs *)
         125
       else

--- a/tools/ci/inria/main
+++ b/tools/ci/inria/main
@@ -186,11 +186,13 @@ case "${OCAML_ARCH}" in
     cleanup=true
     check_make_alldepend=true
     export OCAMLTEST_SKIP_TESTS="$memory_model_tests"
+    init_submodule_flexdll=true
   ;;
   cygwin64)
     cleanup=true
     check_make_alldepend=true
     export OCAMLTEST_SKIP_TESTS="$memory_model_tests"
+    init_submodule_flexdll=true
   ;;
   mingw)
     build='--build=i686-pc-cygwin'


### PR DESCRIPTION
Fixes loading unix.cmxs in Cygwin64