### PR TITLE
[Relocatable] Follow-up 20: Two minor clean-ups in the in-prefix-tests

### DIFF
--- a/testsuite/in_prefix/Makefile.test
+++ b/testsuite/in_prefix/Makefile.test
@@ -63,9 +63,6 @@ test-in-prefix: $(DRIVER) ../tools/main_in_c.$(O) ../tools/poisonedruntime$(EXE)
 	@rm -rf poisoned-runtime
 	@rm -f test-ocamlrun*
 
-SCRUB_ENV = \
-  CAML_LD_LIBRARY_PATH OCAMLLIB CAMLLIB OCAMLPARAM OCAMLRUNPARAM CAMLRUNPARAM
-
 # Generates --without-$(1) if $(2) = false or --with-$(1) otherwise
 bool_to_with = --with$(if $(filter false,$(2)),out)-$(strip $(1))
 

--- a/testsuite/tools/test_ld_conf.ml
+++ b/testsuite/tools/test_ld_conf.ml
@@ -556,7 +556,7 @@ let run config env =
     if not (Sys.file_exists dir) then
       Sys.mkdir dir 0o775
     else if not (Sys.is_directory dir) then begin
-      Sys.rmdir dir;
+      Sys.remove dir;
       Sys.mkdir dir 0o775
     end
   in


### PR DESCRIPTION
Dead code in the Makefile and the less-trodden path in Test_ld_conf.ensure_dir contained an obvious incorrect function call...