### PR TITLE
[Relocatable] Follow-up 16: Don't pass system libraries to `ld -r`

### DIFF
--- a/Changes
+++ b/Changes
@@ -456,6 +456,12 @@ Working version
 * #14388: Remove support for `let rec (module M : S) = e1 in e2`.
   (Alistair O'Brien, review by Vincent Laviron and Gabriel Scherer)
 
+- #14???: `-l` libraries are no longer given to the partial linker (for
+  `-output-complete-obj`) if `ocamlc`/`ocamlopt` cannot resolve them in the
+  current search path. Allows system libraries (e.g. `-lzstd`) to be specified
+  in .cma or .cmxa files without breaking `-output-complete-obj`.
+  (David Allsopp, review by ???)
+
 ### Build system:
 
 - #13810: Support build of cross compilers to native freestanding targets

--- a/testsuite/tools/testLinkModes.ml
+++ b/testsuite/tools/testLinkModes.ml
@@ -558,16 +558,11 @@ let compile_test usr_bin_sh config env test test_program description =
           f ~clibs:[]
             ["-output-complete-obj"; "-noautolink"; "-cclib"; "-lunixbyt"]
       | Output_complete_obj(C_ocamlc, Shared) ->
-          (* The partial linker doesn't correctly process
-             -runtime-variant _shared, as the .so gets passed to the partial
-             linker. On macOS, this causes a warning; on other systems, it's an
-             error. *)
-          let compilation_exit_code = fails_if (Config.system <> "macosx") in
           (* Shared compilation isn't available on native Windows and fails on
              Cygwin *)
           let linker_exit_code = fails_if (Sys.win32 || Sys.cygwin) in
-          f ~use_shared_runtime:true ~clibs:[] ~compilation_exit_code
-            ~linker_exit_code ["-output-complete-obj"]
+          f ~use_shared_runtime:true ~clibs:[] ~linker_exit_code
+            ["-output-complete-obj"]
       | Output_complete_obj(C_ocamlopt, Static) ->
           let linker_exit_code =
             (* cf. ocaml/ocaml#13692 - linking fails on ppc64 *)
@@ -576,21 +571,15 @@ let compile_test usr_bin_sh config env test test_program description =
             else
               0
           in
-          (* At the moment, the partial linker will pass -lzstd to ld -r which
-             will (normally) fail). Until this is done, pass the libraries
-             manually, using -noautolink. *)
           f ~mode:Native ~clibs:[Config.compression_c_libraries]
-            ~linker_exit_code
-            ["-output-complete-obj"; "-noautolink"; "-cclib"; "-lunixnat";
-                                                    "-cclib"; "-lcomprmarsh"]
+            ~linker_exit_code ["-output-complete-obj"]
       | Output_complete_obj(C_ocamlopt, Shared) ->
           (* ocamlopt allows the .so to be passed to the partial linker which
              fails with GNU ld, but not with the macOS linker *)
           let compilation_exit_code = fails_if (Config.system <> "macosx") in
           f ~mode:Native ~use_shared_runtime:true
             ~compilation_exit_code ~clibs:[Config.compression_c_libraries]
-            ["-output-complete-obj"; "-noautolink"; "-cclib"; "-lunixnat";
-                                                    "-cclib"; "-lcomprmarsh"]
+            ["-output-complete-obj"]
       | Output_complete_exe Static ->
           f ~calls_linker:true ["-output-complete-exe"]
       | Output_complete_exe Shared ->

--- a/utils/ccomp.ml
+++ b/utils/ccomp.ml
@@ -153,16 +153,15 @@ let create_archive archive file_list =
                 (quote_files ~response_files:Config.ar_supports_response_files
                   file_list))
 
-let expand_libname cclibs =
-  cclibs |> List.map (fun cclib ->
-    if String.starts_with ~prefix:"-l" cclib then
-      let libname =
-        "lib" ^ String.sub cclib 2 (String.length cclib - 2) ^ Config.ext_lib in
-      try
-        Load_path.find libname
-      with Not_found ->
-        libname
-    else cclib)
+let expand_libname cclib =
+  if String.starts_with ~prefix:"-l" cclib then
+    let libname =
+      "lib" ^ String.sub cclib 2 (String.length cclib - 2) ^ Config.ext_lib in
+    try
+      Some (Load_path.find libname)
+    with Not_found ->
+      None
+  else Some cclib
 
 type link_mode =
   | Exe
@@ -182,11 +181,16 @@ let call_linker mode output_name files extra =
   Profile.record_call "c-linker" (fun () ->
     let cmd =
       if mode = Partial then
-        let (l_prefix, files) =
+        let l_prefix =
           match Config.ccomp_type with
-          | "msvc" -> ("/libpath:", expand_libname files)
-          | _ -> ("-L", files)
+          | "msvc" -> "/libpath:"
+          | _ -> "-L"
         in
+        (* For partial linking, only include -llib if -llib can be found in the
+           current search path. For ld -r, this PATH is (usually) limited to the
+           -L directories. This should cause OCaml libraries to be linked, but
+           not any system libraries mentioned in .cma/.cmxa files. *)
+        let files = List.filter_map expand_libname files in
         Printf.sprintf "%s%s %s %s %s"
           Config.native_pack_linker
           (Filename.quote output_name)


### PR DESCRIPTION
`ld -r` (certainly in GNU binutils) has an empty search path - co-opt the MSVC search code and always resolve libraries when partial linking, except this time _ignore_ the ones which are missing. This seems to fit the rest of -output-complete-obj, given that the _standard_ C libraries are also omitted (-lm, -lpthread, etc.)