### PR TITLE
Raw identifier syntax build regression - OxCaml version

### DIFF
--- a/.depend
+++ b/.depend
@@ -357,11 +357,26 @@ parsing/docstrings.cmx : \
 parsing/docstrings.cmi : \
     parsing/parsetree.cmi \
     parsing/location.cmi
+parsing/keywords.cmo : \
+    utils/misc.cmi \
+    parsing/keywords_token.cmi \
+    parsing/keywords.cmi
+parsing/keywords.cmx : \
+    utils/misc.cmx \
+    parsing/keywords_token.cmi \
+    parsing/keywords.cmi
+parsing/keywords.cmi : \
+    parsing/keywords_token.cmi
+parsing/keywords_token.cmi : \
+    parsing/parser.cmi \
+    parsing/location.cmi \
+    parsing/docstrings.cmi
 parsing/lexer.cmo : \
     utils/warnings.cmi \
     parsing/parser.cmi \
     utils/misc.cmi \
     parsing/location.cmi \
+    parsing/keywords.cmi \
     parsing/docstrings.cmi \
     parsing/lexer.cmi
 parsing/lexer.cmx : \
@@ -369,6 +384,7 @@ parsing/lexer.cmx : \
     parsing/parser.cmx \
     utils/misc.cmx \
     parsing/location.cmx \
+    parsing/keywords.cmx \
     parsing/docstrings.cmx \
     parsing/lexer.cmi
 parsing/lexer.cmi : \
@@ -456,14 +472,14 @@ parsing/pprintast.cmo : \
     parsing/parsetree.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
-    parsing/lexer.cmi \
+    parsing/keywords.cmi \
     parsing/asttypes.cmi \
     parsing/pprintast.cmi
 parsing/pprintast.cmx : \
     parsing/parsetree.cmi \
     parsing/longident.cmx \
     parsing/location.cmx \
-    parsing/lexer.cmx \
+    parsing/keywords.cmx \
     parsing/asttypes.cmi \
     parsing/pprintast.cmi
 parsing/pprintast.cmi : \
@@ -929,13 +945,13 @@ typing/mtype.cmi : \
 typing/oprint.cmo : \
     parsing/pprintast.cmi \
     typing/outcometree.cmi \
-    parsing/lexer.cmi \
+    parsing/keywords.cmi \
     parsing/asttypes.cmi \
     typing/oprint.cmi
 typing/oprint.cmx : \
     parsing/pprintast.cmx \
     typing/outcometree.cmi \
-    parsing/lexer.cmx \
+    parsing/keywords.cmx \
     parsing/asttypes.cmi \
     typing/oprint.cmi
 typing/oprint.cmi : \
@@ -991,11 +1007,11 @@ typing/parmatch.cmi : \
     typing/env.cmi \
     parsing/asttypes.cmi
 typing/path.cmo : \
-    parsing/lexer.cmi \
+    parsing/keywords.cmi \
     typing/ident.cmi \
     typing/path.cmi
 typing/path.cmx : \
-    parsing/lexer.cmx \
+    parsing/keywords.cmx \
     typing/ident.cmx \
     typing/path.cmi
 typing/path.cmi : \

--- a/.gitignore
+++ b/.gitignore
@@ -218,6 +218,7 @@ META
 /otherlibs/dynlink/dynlink_compilerlibs/.depend
 /otherlibs/unix/unix.ml
 
+/parsing/keywords_token.mli
 /parsing/parser.ml
 /parsing/parser.mli
 /parsing/lexer.ml

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ parsing_SOURCES = $(addprefix parsing/, \
   builtin_attributes.mli builtin_attributes.ml \
   camlinternalMenhirLib.mli camlinternalMenhirLib.ml \
   parser.mly \
+  keywords_token.mli keywords.mli keywords.ml \
   lexer.mll \
   pprintast.mli pprintast.ml \
   parse.mli parse.ml \
@@ -1654,10 +1655,22 @@ endif
 	$(V_GEN)sed "s/MenhirLib/CamlinternalMenhirLib/g" $< > $@
 parsing/parser.mli: boot/menhir/parser.mli
 	$(V_GEN)sed "s/MenhirLib/CamlinternalMenhirLib/g" $< > $@
+# The Keywords_token module is needed as an unfortunate indirection between
+# Keywords and Parser. It simply duplicates Parser.token but since it is in an
+# .mli-only module, doesn't cause a dependency between keywords.cmx and
+# parser.cmx.
+parsing/keywords_token.mli: boot/menhir/parser.mli
+	$(V_GEN){ \
+	  echo 'type token = Parser.token ='; \
+	  grep '^  |' boot/menhir/parser.mli; } > $@
 
 beforedepend:: parsing/camlinternalMenhirLib.ml \
   parsing/camlinternalMenhirLib.mli \
-  parsing/parser.ml parsing/parser.mli
+  parsing/parser.ml parsing/parser.mli \
+  parsing/keywords_token.mli
+
+partialclean::
+	rm -f parsing/keywords_token.mli
 
 partialclean:: partialclean-menhir
 
@@ -2182,6 +2195,7 @@ ocamlprof_SOURCES = \
   builtin_attributes.mli builtin_attributes.ml \
   camlinternalMenhirLib.mli camlinternalMenhirLib.ml \
   parser.mli parser.ml \
+  keywords.mli keywords.ml \
   lexer.mli lexer.ml \
   pprintast.mli pprintast.ml \
   parse.mli parse.ml \

--- a/otherlibs/dynlink/Makefile
+++ b/otherlibs/dynlink/Makefile
@@ -66,6 +66,7 @@ NATOBJS=native/dynlink_compilerlibs.cmx dynlink_types.cmx \
 COMPILERLIBS_INTFS=\
   parsing/asttypes.mli \
   parsing/parsetree.mli \
+  parsing/keywords_token.mli \
   typing/outcometree.mli \
   typing/value_rec_types.mli \
   file_formats/cmo_format.mli \
@@ -101,6 +102,7 @@ COMPILERLIBS_SOURCES=\
   parsing/ast_mapper.ml \
   parsing/camlinternalMenhirLib.ml \
   parsing/parser.ml \
+  parsing/keywords.ml \
   parsing/lexer.ml \
   parsing/attr_helper.ml \
   typing/ident.ml \

--- a/parsing/keywords.ml
+++ b/parsing/keywords.ml
@@ -1,0 +1,84 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* The table of keywords *)
+
+open Keywords_token
+
+let keyword_table =
+  Misc.create_hashtable 149 [
+    "and", AND;
+    "as", AS;
+    "assert", ASSERT;
+    "begin", BEGIN;
+    "class", CLASS;
+    "constraint", CONSTRAINT;
+    "do", DO;
+    "done", DONE;
+    "downto", DOWNTO;
+    "else", ELSE;
+    "end", END;
+    "exception", EXCEPTION;
+    "external", EXTERNAL;
+    "false", FALSE;
+    "for", FOR;
+    "fun", FUN;
+    "function", FUNCTION;
+    "functor", FUNCTOR;
+    "if", IF;
+    "in", IN;
+    "include", INCLUDE;
+    "inherit", INHERIT;
+    "initializer", INITIALIZER;
+    "lazy", LAZY;
+    "let", LET;
+    "match", MATCH;
+    "method", METHOD;
+    "module", MODULE;
+    "mutable", MUTABLE;
+    "new", NEW;
+    "nonrec", NONREC;
+    "object", OBJECT;
+    "of", OF;
+    "open", OPEN;
+    "or", OR;
+(*  "parser", PARSER; *)
+    "private", PRIVATE;
+    "rec", REC;
+    "sig", SIG;
+    "struct", STRUCT;
+    "then", THEN;
+    "to", TO;
+    "true", TRUE;
+    "try", TRY;
+    "type", TYPE;
+    "val", VAL;
+    "virtual", VIRTUAL;
+    "when", WHEN;
+    "while", WHILE;
+    "with", WITH;
+
+    "lor", INFIXOP3("lor"); (* Should be INFIXOP2 *)
+    "lxor", INFIXOP3("lxor"); (* Should be INFIXOP2 *)
+    "mod", INFIXOP3("mod");
+    "land", INFIXOP3("land");
+    "lsl", INFIXOP4("lsl");
+    "lsr", INFIXOP4("lsr");
+    "asr", INFIXOP4("asr")
+]
+
+let is_keyword = Hashtbl.mem keyword_table
+
+let token_of_string = Hashtbl.find keyword_table

--- a/parsing/keywords.mli
+++ b/parsing/keywords.mli
@@ -1,0 +1,18 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+val is_keyword : string -> bool
+
+val token_of_string : string -> Keywords_token.token

--- a/parsing/lexer.mli
+++ b/parsing/lexer.mli
@@ -41,8 +41,6 @@ exception Error of error * Location.t
 val in_comment : unit -> bool
 val in_string : unit -> bool
 
-val is_keyword : string -> bool
-
 val print_warnings : bool ref
 val handle_docstrings: bool ref
 val comments : unit -> (string * Location.t) list

--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -34,70 +34,6 @@ type error =
 
 exception Error of error * Location.t
 
-(* The table of keywords *)
-
-let keyword_table =
-  create_hashtable 149 [
-    "and", AND;
-    "as", AS;
-    "assert", ASSERT;
-    "begin", BEGIN;
-    "class", CLASS;
-    "constraint", CONSTRAINT;
-    "do", DO;
-    "done", DONE;
-    "downto", DOWNTO;
-    "else", ELSE;
-    "end", END;
-    "exception", EXCEPTION;
-    "external", EXTERNAL;
-    "false", FALSE;
-    "for", FOR;
-    "fun", FUN;
-    "function", FUNCTION;
-    "functor", FUNCTOR;
-    "if", IF;
-    "in", IN;
-    "include", INCLUDE;
-    "inherit", INHERIT;
-    "initializer", INITIALIZER;
-    "lazy", LAZY;
-    "let", LET;
-    "match", MATCH;
-    "method", METHOD;
-    "module", MODULE;
-    "mutable", MUTABLE;
-    "new", NEW;
-    "nonrec", NONREC;
-    "object", OBJECT;
-    "of", OF;
-    "open", OPEN;
-    "or", OR;
-(*  "parser", PARSER; *)
-    "private", PRIVATE;
-    "rec", REC;
-    "sig", SIG;
-    "struct", STRUCT;
-    "then", THEN;
-    "to", TO;
-    "true", TRUE;
-    "try", TRY;
-    "type", TYPE;
-    "val", VAL;
-    "virtual", VIRTUAL;
-    "when", WHEN;
-    "while", WHILE;
-    "with", WITH;
-
-    "lor", INFIXOP3("lor"); (* Should be INFIXOP2 *)
-    "lxor", INFIXOP3("lxor"); (* Should be INFIXOP2 *)
-    "mod", INFIXOP3("mod");
-    "land", INFIXOP3("land");
-    "lsl", INFIXOP4("lsl");
-    "lsr", INFIXOP4("lsr");
-    "asr", INFIXOP4("asr")
-]
-
 (* To buffer string literals *)
 
 let string_buffer = Buffer.create 256
@@ -255,10 +191,8 @@ let uchar_for_uchar_escape lexbuf =
       illegal_escape lexbuf
         (Printf.sprintf "%X is not a Unicode scalar value" cp)
 
-let is_keyword name = Hashtbl.mem keyword_table name
-
 let check_label_name lexbuf name =
-  if is_keyword name then error lexbuf (Keyword_as_label name)
+  if Keywords.is_keyword name then error lexbuf (Keyword_as_label name)
 
 (* Update the current location with file name and line number. *)
 
@@ -439,7 +373,7 @@ rule token = parse
   | raw_ident_escape (lowercase identchar * as name)
       { LIDENT name }
   | lowercase identchar * as name
-      { try Hashtbl.find keyword_table name
+      { try Keywords.token_of_string name
         with Not_found -> LIDENT name }
   | lowercase_latin1 identchar_latin1 * as name
       { warn_latin1 lexbuf; LIDENT name }

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -99,7 +99,7 @@ let needs_spaces txt =
   operator. *)
 let ident_of_name ppf txt =
   let format : (_, _, _) format =
-    if Lexer.is_keyword txt then "\\#%s"
+    if Keywords.is_keyword txt then "\\#%s"
     else if not (needs_parens txt) then "%s"
     else if needs_spaces txt then "(@;%s@;)"
     else "(%s)"
@@ -282,7 +282,7 @@ let tyvar_of_name s =
     (* without the space, this would be parsed as
        a character literal *)
     "' " ^ s
-  else if Lexer.is_keyword s then
+  else if Keywords.is_keyword s then
     "'\\#" ^ s
   else if String.equal s "_" then
     s

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -24,7 +24,7 @@ let cautious f ppf arg =
 
 let print_lident ppf = function
   | "::" -> pp_print_string ppf "(::)"
-  | s when Lexer.is_keyword s -> fprintf ppf "\\#%s" s
+  | s when Keywords.is_keyword s -> fprintf ppf "\\#%s" s
   | s -> pp_print_string ppf s
 
 let rec print_ident ppf =
@@ -63,7 +63,7 @@ let parenthesized_ident name =
 let value_ident ppf name =
   if parenthesized_ident name then
     fprintf ppf "( %s )" name
-  else if Lexer.is_keyword name then
+  else if Keywords.is_keyword name then
     fprintf ppf "\\#%s" name
   else
     pp_print_string ppf name

--- a/typing/path.ml
+++ b/typing/path.ml
@@ -91,7 +91,7 @@ let rec scope = function
 let kfalse _ = false
 
 let maybe_escape s =
-  if Lexer.is_keyword s then "\\#" ^ s else s
+  if Keywords.is_keyword s then "\\#" ^ s else s
 
 let rec name ?(paren=kfalse) = function
     Pident id -> maybe_escape (Ident.name id)


### PR DESCRIPTION
```console
$ hyperfine -p 'git clean -dfX; git checkout {sha}; ./configure --disable-dependency-generation' -L sha 717d9ba2c8,76a2ac4b37,da1cc7acd8,5663fc6a56 'make -j'`

```
- [717d9ba2c8](https://github.com/ocaml/ocaml/commit/717d9ba2c8) - trunk prior to `PR#12323` being merged
- [76a2ac4b37](https://github.com/ocaml/ocaml/commit/76a2ac4b37) - merge of `PR#12323`
- [da1cc7acd8](https://github.com/ocaml/ocaml/commit/da1cc7acd8) - current 5.2 branch
- [5663fc6a56](https://github.com/ocaml/ocaml/commit/5663fc6a56) - this PR