### PR TITLE
Raw identifier syntax build regression - trunk version

### DIFF
--- a/.depend
+++ b/.depend
@@ -406,11 +406,24 @@ parsing/docstrings.cmx : \
 parsing/docstrings.cmi : \
     parsing/parsetree.cmi \
     parsing/location.cmi
+parsing/keywords.cmo : \
+    parsing/keywords_token.cmi \
+    parsing/keywords.cmi
+parsing/keywords.cmx : \
+    parsing/keywords_token.cmi \
+    parsing/keywords.cmi
+parsing/keywords.cmi : \
+    parsing/keywords_token.cmi
+parsing/keywords_token.cmi : \
+    parsing/parser.cmi \
+    parsing/location.cmi \
+    parsing/docstrings.cmi
 parsing/lexer.cmo : \
     utils/warnings.cmi \
     parsing/parser.cmi \
     utils/misc.cmi \
     parsing/location.cmi \
+    parsing/keywords.cmi \
     utils/format_doc.cmi \
     parsing/docstrings.cmi \
     parsing/lexer.cmi
@@ -419,6 +432,7 @@ parsing/lexer.cmx : \
     parsing/parser.cmx \
     utils/misc.cmx \
     parsing/location.cmx \
+    parsing/keywords.cmx \
     utils/format_doc.cmx \
     parsing/docstrings.cmx \
     parsing/lexer.cmi
@@ -517,7 +531,7 @@ parsing/pprintast.cmo : \
     parsing/parsetree.cmi \
     parsing/longident.cmi \
     parsing/location.cmi \
-    parsing/lexer.cmi \
+    parsing/keywords.cmi \
     utils/format_doc.cmi \
     parsing/asttypes.cmi \
     parsing/pprintast.cmi
@@ -525,7 +539,7 @@ parsing/pprintast.cmx : \
     parsing/parsetree.cmi \
     parsing/longident.cmx \
     parsing/location.cmx \
-    parsing/lexer.cmx \
+    parsing/keywords.cmx \
     utils/format_doc.cmx \
     parsing/asttypes.cmx \
     parsing/pprintast.cmi
@@ -1127,7 +1141,7 @@ typing/oprint.cmo : \
     parsing/pprintast.cmi \
     typing/outcometree.cmi \
     utils/misc.cmi \
-    parsing/lexer.cmi \
+    parsing/keywords.cmi \
     utils/format_doc.cmi \
     parsing/asttypes.cmi \
     typing/oprint.cmi
@@ -1135,7 +1149,7 @@ typing/oprint.cmx : \
     parsing/pprintast.cmx \
     typing/outcometree.cmi \
     utils/misc.cmx \
-    parsing/lexer.cmx \
+    parsing/keywords.cmx \
     utils/format_doc.cmx \
     parsing/asttypes.cmx \
     typing/oprint.cmi
@@ -1257,12 +1271,12 @@ typing/parmatch.cmi : \
     typing/data_types.cmi \
     parsing/asttypes.cmi
 typing/path.cmo : \
-    parsing/lexer.cmi \
+    parsing/keywords.cmi \
     typing/ident.cmi \
     utils/format_doc.cmi \
     typing/path.cmi
 typing/path.cmx : \
-    parsing/lexer.cmx \
+    parsing/keywords.cmx \
     typing/ident.cmx \
     utils/format_doc.cmx \
     typing/path.cmi

--- a/.gitignore
+++ b/.gitignore
@@ -220,6 +220,7 @@ META
 /otherlibs/dynlink/native/dynlink.mli
 /otherlibs/unix/unix.ml
 
+/parsing/keywords_token.mli
 /parsing/parser.ml
 /parsing/parser.mli
 /parsing/lexer.ml

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ parsing_SOURCES = $(addprefix parsing/, \
   builtin_attributes.mli builtin_attributes.ml \
   camlinternalMenhirLib.mli camlinternalMenhirLib.ml \
   parser.mly \
+  keywords_token.mli keywords.mli keywords.ml \
   lexer.mll \
   pprintast.mli pprintast.ml \
   parse.mli parse.ml \
@@ -1780,10 +1781,22 @@ endif
 	$(V_GEN)sed "s/MenhirLib/CamlinternalMenhirLib/g" $< > $@
 parsing/parser.mli: boot/menhir/parser.mli
 	$(V_GEN)sed "s/MenhirLib/CamlinternalMenhirLib/g" $< > $@
+# The Keywords_token module is needed as an unfortunate indirection between
+# Keywords and Parser. It simply duplicates Parser.token but since it is in an
+# .mli-only module, doesn't cause a dependency between keywords.cmx and
+# parser.cmx.
+parsing/keywords_token.mli: boot/menhir/parser.mli
+	$(V_GEN){ \
+	  echo 'type token = Parser.token ='; \
+	  grep '^  |' boot/menhir/parser.mli; } > $@
 
 beforedepend:: parsing/camlinternalMenhirLib.ml \
   parsing/camlinternalMenhirLib.mli \
-  parsing/parser.ml parsing/parser.mli
+  parsing/parser.ml parsing/parser.mli \
+  parsing/keywords_token.mli
+
+partialclean::
+	rm -f parsing/keywords_token.mli
 
 partialclean:: partialclean-menhir
 
@@ -2363,6 +2376,7 @@ ocamlprof_SOURCES = \
   builtin_attributes.mli builtin_attributes.ml \
   camlinternalMenhirLib.mli camlinternalMenhirLib.ml \
   parser.mli parser.ml \
+  keywords_token.mli keywords.mli keywords.ml \
   lexer.mli lexer.ml \
   pprintast.mli pprintast.ml \
   parse.mli parse.ml \

--- a/parsing/keywords.ml
+++ b/parsing/keywords.ml
@@ -1,0 +1,110 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* The table of keywords *)
+
+open Keywords_token
+
+let keyword_table = Hashtbl.create 149
+
+let all_keywords =
+  let v5_3 = Some (5,3) in
+  let v1_0 = Some (1,0) in
+  let v1_6 = Some (1,6) in
+  let v4_2 = Some (4,2) in
+  let always = None in
+  [
+    "and", AND, always;
+    "as", AS, always;
+    "assert", ASSERT, v1_6;
+    "begin", BEGIN, always;
+    "class", CLASS, v1_0;
+    "constraint", CONSTRAINT, v1_0;
+    "do", DO, always;
+    "done", DONE, always;
+    "downto", DOWNTO, always;
+    "effect", EFFECT, v5_3;
+    "else", ELSE, always;
+    "end", END, always;
+    "exception", EXCEPTION, always;
+    "external", EXTERNAL, always;
+    "false", FALSE, always;
+    "for", FOR, always;
+    "fun", FUN, always;
+    "function", FUNCTION, always;
+    "functor", FUNCTOR, always;
+    "if", IF, always;
+    "in", IN, always;
+    "include", INCLUDE, always;
+    "inherit", INHERIT, v1_0;
+    "initializer", INITIALIZER, v1_0;
+    "lazy", LAZY, v1_6;
+    "let", LET, always;
+    "match", MATCH, always;
+    "method", METHOD, v1_0;
+    "module", MODULE, always;
+    "mutable", MUTABLE, always;
+    "new", NEW, v1_0;
+    "nonrec", NONREC, v4_2;
+    "object", OBJECT, v1_0;
+    "of", OF, always;
+    "open", OPEN, always;
+    "or", OR, always;
+(*  "parser", PARSER; *)
+    "private", PRIVATE, v1_0;
+    "rec", REC, always;
+    "sig", SIG, always;
+    "struct", STRUCT, always;
+    "then", THEN, always;
+    "to", TO, always;
+    "true", TRUE, always;
+    "try", TRY, always;
+    "type", TYPE, always;
+    "val", VAL, always;
+    "virtual", VIRTUAL, v1_0;
+    "when", WHEN, always;
+    "while", WHILE, always;
+    "with", WITH, always;
+
+    "lor", INFIXOP3("lor"), always; (* Should be INFIXOP2 *)
+    "lxor", INFIXOP3("lxor"), always; (* Should be INFIXOP2 *)
+    "mod", INFIXOP3("mod"), always;
+    "land", INFIXOP3("land"), always;
+    "lsl", INFIXOP4("lsl"), always;
+    "lsr", INFIXOP4("lsr"), always;
+    "asr", INFIXOP4("asr"), always
+]
+
+let init (version,keywords) =
+  let greater (x:(int*int) option) (y:(int*int) option) =
+    match x, y with
+    | None, _ | _, None -> true
+    | Some x, Some y -> x >= y
+  in
+  let tbl = keyword_table in
+  Hashtbl.clear tbl;
+  let add_keyword (name, token, since) =
+    if greater version since then Hashtbl.replace tbl name (Some token)
+  in
+  List.iter add_keyword all_keywords;
+  List.iter (fun name ->
+    match List.find (fun (n,_,_) -> n = name) all_keywords with
+    | (_,tok,_) -> Hashtbl.replace tbl name (Some tok)
+    | exception Not_found -> Hashtbl.replace tbl name None
+    ) keywords
+
+let is_keyword = Hashtbl.mem keyword_table
+
+let token_of_string = Hashtbl.find keyword_table

--- a/parsing/keywords.mli
+++ b/parsing/keywords.mli
@@ -1,0 +1,20 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*             Xavier Leroy, projet Cristal, INRIA Rocquencourt           *)
+(*                                                                        *)
+(*   Copyright 1996 Institut National de Recherche en Informatique et     *)
+(*     en Automatique.                                                    *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+val init : (int*int) option * string list -> unit
+
+val is_keyword : string -> bool
+
+val token_of_string : string -> Keywords_token.token option

--- a/parsing/lexer.mli
+++ b/parsing/lexer.mli
@@ -47,8 +47,6 @@ exception Error of error * Location.t
 val in_comment : unit -> bool
 val in_string : unit -> bool
 
-val is_keyword : string -> bool
-
 val print_warnings : bool ref
 val handle_docstrings: bool ref
 val comments : unit -> (string * Location.t) list

--- a/parsing/lexer.mll
+++ b/parsing/lexer.mll
@@ -40,98 +40,6 @@ type error =
 
 exception Error of error * Location.t
 
-(* The table of keywords *)
-
-let all_keywords =
-  let v5_3 = Some (5,3) in
-  let v1_0 = Some (1,0) in
-  let v1_6 = Some (1,6) in
-  let v4_2 = Some (4,2) in
-  let always = None in
-  [
-    "and", AND, always;
-    "as", AS, always;
-    "assert", ASSERT, v1_6;
-    "begin", BEGIN, always;
-    "class", CLASS, v1_0;
-    "constraint", CONSTRAINT, v1_0;
-    "do", DO, always;
-    "done", DONE, always;
-    "downto", DOWNTO, always;
-    "effect", EFFECT, v5_3;
-    "else", ELSE, always;
-    "end", END, always;
-    "exception", EXCEPTION, always;
-    "external", EXTERNAL, always;
-    "false", FALSE, always;
-    "for", FOR, always;
-    "fun", FUN, always;
-    "function", FUNCTION, always;
-    "functor", FUNCTOR, always;
-    "if", IF, always;
-    "in", IN, always;
-    "include", INCLUDE, always;
-    "inherit", INHERIT, v1_0;
-    "initializer", INITIALIZER, v1_0;
-    "lazy", LAZY, v1_6;
-    "let", LET, always;
-    "match", MATCH, always;
-    "method", METHOD, v1_0;
-    "module", MODULE, always;
-    "mutable", MUTABLE, always;
-    "new", NEW, v1_0;
-    "nonrec", NONREC, v4_2;
-    "object", OBJECT, v1_0;
-    "of", OF, always;
-    "open", OPEN, always;
-    "or", OR, always;
-(*  "parser", PARSER; *)
-    "private", PRIVATE, v1_0;
-    "rec", REC, always;
-    "sig", SIG, always;
-    "struct", STRUCT, always;
-    "then", THEN, always;
-    "to", TO, always;
-    "true", TRUE, always;
-    "try", TRY, always;
-    "type", TYPE, always;
-    "val", VAL, always;
-    "virtual", VIRTUAL, v1_0;
-    "when", WHEN, always;
-    "while", WHILE, always;
-    "with", WITH, always;
-
-    "lor", INFIXOP3("lor"), always; (* Should be INFIXOP2 *)
-    "lxor", INFIXOP3("lxor"), always; (* Should be INFIXOP2 *)
-    "mod", INFIXOP3("mod"), always;
-    "land", INFIXOP3("land"), always;
-    "lsl", INFIXOP4("lsl"), always;
-    "lsr", INFIXOP4("lsr"), always;
-    "asr", INFIXOP4("asr"), always
-]
-
-
-let keyword_table = Hashtbl.create 149
-
-let populate_keywords (version,keywords) =
-  let greater (x:(int*int) option) (y:(int*int) option) =
-    match x, y with
-    | None, _ | _, None -> true
-    | Some x, Some y -> x >= y
-  in
-  let tbl = keyword_table in
-  Hashtbl.clear tbl;
-  let add_keyword (name, token, since) =
-    if greater version since then Hashtbl.replace tbl name (Some token)
-  in
-  List.iter add_keyword all_keywords;
-  List.iter (fun name ->
-    match List.find (fun (n,_,_) -> n = name) all_keywords with
-    | (_,tok,_) -> Hashtbl.replace tbl name (Some tok)
-    | exception Not_found -> Hashtbl.replace tbl name None
-    ) keywords
-
-
 (* To buffer string literals *)
 
 let string_buffer = Buffer.create 256
@@ -322,11 +230,8 @@ let lax_delim raw_name =
      if Utf8_lexeme.is_lowercase name then Some name
      else None
 
-let is_keyword name =
-  Hashtbl.mem keyword_table name
-
 let find_keyword lexbuf name =
-  match Hashtbl.find keyword_table name with
+  match Keywords.token_of_string name with
   | Some x -> x
   | None -> error lexbuf (Unknown_keyword name)
   | exception Not_found -> LIDENT name
@@ -334,7 +239,7 @@ let find_keyword lexbuf name =
 let check_label_name ?(raw_escape=false) lexbuf name =
   if Utf8_lexeme.is_capitalized name then
     error lexbuf (Capitalized_label name);
-  if not raw_escape && is_keyword name then
+  if not raw_escape && Keywords.is_keyword name then
     error lexbuf (Keyword_as_label name)
 
 (* Update the current location with file name and line number. *)
@@ -1006,7 +911,7 @@ and skip_hash_bang = parse
       loop NoLine Initial lexbuf
 
   let init ?(keyword_edition=None,[]) () =
-    populate_keywords keyword_edition;
+    Keywords.init keyword_edition;
     is_in_string := false;
     comment_start_loc := [];
     comment_list := [];

--- a/parsing/pprintast.ml
+++ b/parsing/pprintast.ml
@@ -132,7 +132,7 @@ let tyvar_of_name s =
     (* without the space, this would be parsed as
        a character literal *)
     "' " ^ s
-  else if Lexer.is_keyword s then
+  else if Keywords.is_keyword s then
     "'\\#" ^ s
   else if String.equal s "_" then
     s
@@ -145,7 +145,7 @@ module Doc = struct
    operator. *)
   let ident_of_name ~kind ppf txt =
     let format : (_, _, _) format =
-      if Lexer.is_keyword txt then begin
+      if Keywords.is_keyword txt then begin
         match kind, txt with
         | Constr, ("true"|"false") -> "%s"
         | _ ->  "\\#%s"

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -24,7 +24,7 @@ let cautious f ppf arg =
 
 let print_lident ppf = function
   | "::" -> pp_print_string ppf "(::)"
-  | s when Lexer.is_keyword s -> fprintf ppf "\\#%s" s
+  | s when Keywords.is_keyword s -> fprintf ppf "\\#%s" s
   | s -> pp_print_string ppf s
 
 let rec print_ident ppf =
@@ -44,7 +44,7 @@ let parenthesized_ident name =
 let value_ident ppf name =
   if parenthesized_ident name then
     fprintf ppf "( %s )" name
-  else if Lexer.is_keyword name then
+  else if Keywords.is_keyword name then
     fprintf ppf "\\#%s" name
   else
     pp_print_string ppf name

--- a/typing/path.ml
+++ b/typing/path.ml
@@ -91,7 +91,7 @@ let rec scope = function
 let kfalse _ = false
 
 let maybe_escape s =
-  if Lexer.is_keyword s then "\\#" ^ s else s
+  if Keywords.is_keyword s then "\\#" ^ s else s
 
 let rec name ?(paren=kfalse) = function
     Pident id -> maybe_escape (Ident.name id)


### PR DESCRIPTION
From a 32-vCPU VM:
```console
$ hyperfine -p 'git clean -dfX; git checkout {sha}; ./configure --disable-dependency-generation' -L sha 717d9ba2c8,76a2ac4b37,da1cc7acd8,5663fc6a56,25b6cc979d,dd07f7b9b4 'make -j'
Benchmark 1: make -j (sha = 717d9ba2c8)
  Time (mean ± σ):     65.664 s ±  0.563 s    [User: 307.606 s, System: 57.598 s]
  Range (min … max):   64.764 s … 66.610 s    10 runs

Benchmark 2: make -j (sha = 76a2ac4b37)
  Time (mean ± σ):     78.664 s ±  0.342 s    [User: 309.817 s, System: 57.670 s]
  Range (min … max):   78.361 s … 79.490 s    10 runs

Benchmark 3: make -j (sha = da1cc7acd8)
  Time (mean ± σ):     78.657 s ±  0.168 s    [User: 322.876 s, System: 58.644 s]
  Range (min … max):   78.453 s … 78.971 s    10 runs

Benchmark 4: make -j (sha = 5663fc6a56)
  Time (mean ± σ):     68.925 s ±  0.171 s    [User: 323.601 s, System: 59.080 s]
  Range (min … max):   68.622 s … 69.175 s    10 runs

Benchmark 5: make -j (sha = 25b6cc979d)
  Time (mean ± σ):     88.860 s ±  0.408 s    [User: 399.498 s, System: 60.469 s]
  Range (min … max):   88.307 s … 89.763 s    10 runs

Benchmark 6: make -j (sha = dd07f7b9b4)
  Time (mean ± σ):     77.913 s ±  0.420 s    [User: 400.786 s, System: 60.522 s]
  Range (min … max):   77.677 s … 79.095 s    10 runs
```
- [717d9ba2c8](https://github.com/ocaml/ocaml/commit/717d9ba2c8) - trunk prior to `PR#12323` being merged
- [76a2ac4b37](https://github.com/ocaml/ocaml/commit/76a2ac4b37) - merge of `PR#12323`
- [da1cc7acd8](https://github.com/ocaml/ocaml/commit/da1cc7acd8) - current 5.2 branch
- [5663fc6a56](https://github.com/ocaml/ocaml/commit/5663fc6a56) - 5.2 version of this PR
- [25b6cc979d](https://github.com/ocaml/ocaml/commit/25b6cc979d) - current trunk
- [dd07f7b9b4](https://github.com/ocaml/ocaml/commit/dd07f7b9b4) - this PR