### PR TITLE
Allow file descriptors to be passed across exec calls

### DIFF
--- a/Changes
+++ b/Changes
@@ -162,6 +162,10 @@ Working version
   party C code using file descriptors.
   (David Allsopp, review by ???)
 
+- #14???: Add Unix.fdopen to allow programs which are started with additional
+  file streams opened to be able to use them portably.
+  (David Allsopp, review by ???)
+
 ### Tools:
 
 - #14055: Invert BUILD_PATH_PREFIX_MAP in directories loaded at startup

--- a/Changes
+++ b/Changes
@@ -138,6 +138,10 @@ Working version
 
 ### Other libraries:
 
+- #9052, #14???: Add Unix.pp_file_descr for use in debugging to provide a
+  printable/loggable representation of Unix.file_descr values.
+  (David Allsopp, review by ???)
+
 * #14046: On Windows, `Unix.kill pid Sys.sigkill` causes the receiving process
   to exit with code ERROR_PROCESS_ABORTED (1067) instead of 0.
   (Nicolás Ojeda Bär, review by Miod Vallat, Antonin Décimo and David Allsopp)

--- a/Changes
+++ b/Changes
@@ -153,6 +153,11 @@ Working version
   instead of ENOENT if the command string is not a valid C string.
   (Antonin Décimo, review by Gabriel Scherer and Nicolás Ojeda Bär)
 
+- #14???: Add a C API in unixsupport.h for allowing manipulation (in C) of
+  Unix.file_descr values in order to facilitate portable interop with third
+  party C code using file descriptors.
+  (David Allsopp, review by ???)
+
 ### Tools:
 
 - #14055: Invert BUILD_PATH_PREFIX_MAP in directories loaded at startup

--- a/otherlibs/unix/Makefile
+++ b/otherlibs/unix/Makefile
@@ -46,8 +46,9 @@ endif
 # C source files common to both Unix and Windows
 COMMON_C_SOURCES = $(addsuffix .c, \
   access addrofstr chdir chmod cst2constr cstringv execv execve execvp fsync \
-  mkdir exit getaddrinfo getcwd gethost gethostname getnameinfo getproto \
-  getserv gmtime mmap_ba putenv rename rmdir socketaddr strofaddr time unlink)
+  mkdir exit fdopen getaddrinfo getcwd gethost gethostname getnameinfo \
+  getproto getserv gmtime mmap_ba putenv rename rmdir socketaddr strofaddr \
+  time unlink)
 
 # OS-specific C source files
 OS_C_SOURCES = $(addsuffix _$(UNIX_OR_WIN32).c, \

--- a/otherlibs/unix/caml/unixsupport.h
+++ b/otherlibs/unix/caml/unixsupport.h
@@ -29,10 +29,9 @@
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #include <wspiapi.h>
+#include <io.h>
 #else /* Unix */
-#ifndef _WIN32
 #include <unistd.h>
-#endif
 #endif
 
 #ifdef __cplusplus
@@ -65,6 +64,7 @@ struct filedescr {
 
 extern value caml_win32_alloc_handle(HANDLE);
 extern value caml_win32_alloc_socket(SOCKET);
+extern value caml_win32_alloc_handle_or_socket(HANDLE);
 
 #define NO_CRT_FD (-1)
 #define GETTING_CRT_FD (-2)
@@ -94,6 +94,56 @@ extern void caml_win32_maperr(DWORD errcode);
 #define CAML_NT_EPOCH_100ns_TICKS 116444736000000000ULL
 
 #endif /* _WIN32 */
+
+/* C API for manipulating Unix.file_descr. There are two separate notions of
+   file descriptor: those of the C Runtime Library (the CRT) and those of the
+   underlying OS. On Unix systems, these two are the same; on Windows, the CRT
+   notion is equivalent to its Unix counterpart, but the OS notion is not. */
+
+#define CAML_UNIX_FILE_DESCR_API
+
+/* Allocates a Unix.file_descr based on an OS file descriptor. */
+#ifndef _WIN32
+Caml_inline value caml_unix_file_descr_of_os(int fd)
+{
+  return Val_int(fd);
+}
+#else
+Caml_inline value caml_unix_file_descr_of_os(HANDLE h)
+{
+  return caml_win32_alloc_handle_or_socket(h);
+}
+#endif
+
+/* Allocates a Unix.file_descr based on a CRT file descriptor. */
+Caml_inline value caml_unix_file_descr_of_fd(int fildes)
+{
+#ifndef _WIN32
+  return caml_unix_file_descr_of_os(fildes);
+#else
+  return caml_unix_file_descr_of_os((HANDLE)_get_osfhandle(fildes));
+#endif
+}
+
+/* Returns the CRT file descriptor associated with a Unix.file_descr. On
+   Windows, this will allocate one, if necessary.
+
+   There is no caml_unix_os_of_file_descr, as this function is not useful. Code
+   which needs to deal with OS file descriptors in a portable way should instead
+   use caml_unix_fd_of_file_descr to obtain a CRT file descriptor and then use
+   CRT functions (for example, _get_osfhandle) to access the OS file descriptor.
+   Using Handle_val, Socket_val and Descr_kind_val is not recommended, as the
+   interface of these is unstable and could change (in particular, there is not
+   a permanent guarantee that a Unix.file_descr always has an OS file descriptor
+   associated with it). */
+Caml_inline int caml_unix_fd_of_file_descr(value fd)
+{
+#ifndef _WIN32
+  return Int_val(fd);
+#else
+  return caml_win32_CRT_fd_of_filedescr(fd);
+#endif
+}
 
 #define Nothing ((value) 0)
 

--- a/otherlibs/unix/channels_win32.c
+++ b/otherlibs/unix/channels_win32.c
@@ -182,3 +182,16 @@ CAMLprim value caml_unix_filedescr_of_fd(value vfd)
   CRT_field_val(res) = crt_fd;
   return res;
 }
+
+CAMLprim value caml_win32_introspect_file_descr(value file_descr)
+{
+  CAMLparam1(file_descr);
+  int fd = caml_win32_get_CRT_fd(file_descr);
+
+  CAMLreturn(
+    caml_alloc_4(0,
+                 caml_copy_nativeint((intnat)Handle_val(file_descr)),
+                 Val_bool(Descr_kind_val(file_descr) == KIND_SOCKET),
+                 (fd == NO_CRT_FD ? Val_none : caml_alloc_some(Val_int(fd))),
+                 Val_bool(Flags_fd_val(file_descr) & FLAGS_FD_IS_BLOCKING)));
+}

--- a/otherlibs/unix/fdopen.c
+++ b/otherlibs/unix/fdopen.c
@@ -1,0 +1,30 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*            David Allsopp, University of Cambridge & Tarides            */
+/*                                                                        */
+/*   Copyright 2025 David Allsopp Ltd.                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+#define CAML_INTERNALS
+
+#include <caml/mlvalues.h>
+#include <caml/fail.h>
+#include "caml/unixsupport.h"
+
+CAMLprim value caml_unix_fdopen(value stream_number)
+{
+  /* Negative stream numbers are invalid and the standard streams should not be
+     retrieved using this function. */
+  int fd = Int_val(stream_number);
+  if (fd < 3)
+    caml_invalid_argument("Unix.fdopen");
+  else
+    return caml_unix_file_descr_of_fd(fd);
+}

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -329,6 +329,23 @@ val nice : int -> int
 type file_descr
 (** The abstract type of file descriptors. *)
 
+val pp_file_descr: ('a -> string -> unit) -> 'a -> file_descr -> unit
+(** Formatter for displaying {!file_descr} values, principally intended for
+    debugging purposes. The format of the text displayed is guaranteed to
+    include all the information the library holds on the given descriptor, but
+    is otherwise unspecified. In particular, the string returned by this
+    function should not be further parsed - see the C API functions in
+    unixsupport.h for details of how to manipulate and construct [file_descr]
+    values in a portable manner from C code.
+
+  {[Format.eprintf "stdin is %a\n" (Unix.pp_file_descr Format.pp_print_string)
+                 Unix.stdin;
+  Printf.eprintf "stdin is %a\n" (Unix.pp_file_descr Out_channel.output_string)
+                 Unix.stdin;
+  ]}
+
+    @since 5.5 *)
+
 val stdin : file_descr
 (** File descriptor for standard input.*)
 

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -355,6 +355,30 @@ val stdout : file_descr
 val stderr : file_descr
 (** File descriptor for standard error. *)
 
+val fdopen : int -> file_descr
+(** [fdopen stream_number] allocates a {!file_descr} corresponding to the given
+    file stream number. The returned [file_descr] inherits the same mode as the
+    file stream (unlike the corresponding function in C, there is no ability to
+    restrict the mode further).
+
+    This function is typically only required where processes are known to be
+    executed (on both Unix and Windows) with file streams opened in addition to
+    the standard streams {!stdin}, {!stdout} and {!stderr}. In this case, the
+    program opens these known file streams at startup.
+
+    When using C libraries which return file stream numbers, these numbers
+    should not be returned to OCaml code, but rather
+    [caml_unix_file_descr_of_fd] should be used in the C stub wrapping such
+    calls to allocate a [file_descr] value to be returned to OCaml code.
+    Likewise, when a [file_descr] value needs to be passed to a function in a
+    C library, [caml_unix_fd_of_file_descr] exists to allow this to be done in
+    the C stub. OCaml code should never need to store a file stream number as an
+    [int].
+
+    @raise Invalid_argument for stream numbers less than 3
+
+    @since 5.5 *)
+
 type open_flag =
     O_RDONLY                    (** Open for reading *)
   | O_WRONLY                    (** Open for writing *)

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -329,6 +329,23 @@ val nice : int -> int
 type file_descr = Unix.file_descr
 (** The abstract type of file descriptors. *)
 
+val pp_file_descr: ('a -> string -> unit) -> 'a -> file_descr -> unit
+(** Formatter for displaying {!file_descr} values, principally intended for
+    debugging purposes. The format of the text displayed is guaranteed to
+    include all the information the library holds on the given descriptor, but
+    is otherwise unspecified. In particular, the string returned by this
+    function should not be further parsed - see the C API functions in
+    unixsupport.h for details of how to manipulate and construct [file_descr]
+    values in a portable manner from C code.
+
+  {[Format.eprintf "stdin is %a\n" (Unix.pp_file_descr Format.pp_print_string)
+                 Unix.stdin;
+  Printf.eprintf "stdin is %a\n" (Unix.pp_file_descr Out_channel.output_string)
+                 Unix.stdin;
+  ]}
+
+    @since 5.5 *)
+
 val stdin : file_descr
 (** File descriptor for standard input.*)
 

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -355,6 +355,30 @@ val stdout : file_descr
 val stderr : file_descr
 (** File descriptor for standard error. *)
 
+val fdopen : int -> file_descr
+(** [fdopen stream_number] allocates a {!file_descr} corresponding to the given
+    file stream number. The returned [file_descr] inherits the same mode as the
+    file stream (unlike the corresponding function in C, there is no ability to
+    restrict the mode further).
+
+    This function is typically only required where processes are known to be
+    executed (on both Unix and Windows) with file streams opened in addition to
+    the standard streams {!stdin}, {!stdout} and {!stderr}. In this case, the
+    program opens these known file streams at startup.
+
+    When using C libraries which return file stream numbers, these numbers
+    should not be returned to OCaml code, but rather
+    [caml_unix_file_descr_of_fd] should be used in the C stub wrapping such
+    calls to allocate a [file_descr] value to be returned to OCaml code.
+    Likewise, when a [file_descr] value needs to be passed to a function in a
+    C library, [caml_unix_fd_of_file_descr] exists to allow this to be done in
+    the C stub. OCaml code should never need to store a file stream number as an
+    [int].
+
+    @raise Invalid_argument for stream numbers less than 3
+
+    @since 5.5 *)
+
 type open_flag = Unix.open_flag =
     O_RDONLY                    (** Open for reading *)
   | O_WRONLY                    (** Open for writing *)

--- a/otherlibs/unix/unix_unix.ml
+++ b/otherlibs/unix/unix_unix.ml
@@ -236,6 +236,8 @@ let stdin = 0
 let stdout = 1
 let stderr = 2
 
+external fdopen : int -> file_descr = "caml_unix_fdopen"
+
 type open_flag =
     O_RDONLY
   | O_WRONLY

--- a/otherlibs/unix/unix_unix.ml
+++ b/otherlibs/unix/unix_unix.ml
@@ -229,6 +229,9 @@ external nice : int -> int = "caml_unix_nice"
 
 type file_descr = int
 
+let pp_file_descr output_string channel descr =
+  output_string channel (Printf.sprintf "<fd %d>" descr)
+
 let stdin = 0
 let stdout = 1
 let stderr = 2

--- a/otherlibs/unix/unix_win32.ml
+++ b/otherlibs/unix/unix_win32.ml
@@ -250,6 +250,27 @@ let nice _ = invalid_arg "Unix.nice not implemented"
 
 type file_descr
 
+external details :
+  file_descr -> nativeint * socket:bool * int option * blocking:bool
+    = "caml_win32_introspect_file_descr"
+
+let pp_file_descr output_string channel descr =
+  let handle, ~socket, fd, ~blocking = details descr in
+  let kind =
+    if socket then
+      "SOCKET"
+    else
+      "HANDLE"
+  in
+  let blocking =
+    if blocking then
+      " (FD_IS_BLOCKING)"
+    else
+      ""
+  in
+  let fd = Option.fold ~none:"" ~some:(Printf.sprintf "; fd %d") fd in
+  output_string channel (Printf.sprintf "<%s 0x%nx%s%s" kind handle blocking fd)
+
 external filedescr_of_unix_fd_num : int -> file_descr
                                   = "caml_unix_filedescr_of_fd"
 

--- a/otherlibs/unix/unix_win32.ml
+++ b/otherlibs/unix/unix_win32.ml
@@ -278,6 +278,8 @@ let stdin = filedescr_of_unix_fd_num 0
 let stdout = filedescr_of_unix_fd_num 1
 let stderr = filedescr_of_unix_fd_num 2
 
+external fdopen : int -> file_descr = "caml_unix_fdopen"
+
 type open_flag =
     O_RDONLY
   | O_WRONLY

--- a/otherlibs/unix/unixsupport_win32.c
+++ b/otherlibs/unix/unixsupport_win32.c
@@ -75,18 +75,15 @@ value caml_win32_alloc_socket(SOCKET s)
   return res;
 }
 
-#if 0
-/* PR#4750: this function is no longer used */
-value win_alloc_handle_or_socket(HANDLE h)
+value caml_win32_alloc_handle_or_socket(HANDLE h)
 {
-  value res = win_alloc_handle(h);
-  int opt;
-  int optlen = sizeof(opt);
-  if (getsockopt((SOCKET) h, SOL_SOCKET, SO_TYPE, (char *)&opt, &optlen) == 0)
-    Descr_kind_val(res) = KIND_SOCKET;
-  return res;
+  int _opt, _optlen = sizeof(int);
+  /* Trivial call to getsockopt to test if h is a SOCKET: values are unused */
+  if (getsockopt((SOCKET)h, SOL_SOCKET, SO_TYPE, (char *)&_opt, &_optlen) == 0)
+    return caml_win32_alloc_socket((SOCKET)h);
+  else
+    return caml_win32_alloc_handle(h);
 }
-#endif
 
 /* Mapping of Windows error codes to POSIX error codes */
 


### PR DESCRIPTION
Parking the HEAD commit until the updates to `Unix.create_process` etc. are done to support an `(int * file_descr) list` optional argument specifying additional fds to be passed in addition to 0, 1 and 2 (requires the updates to `Unix.create_process` for correct operation of fds on Windows as well)